### PR TITLE
Tests for the package core, shaped to survive the MCP move

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,112 @@
+# A separate workflow from publish.yaml on purpose: that file's NAME is bound
+# to PyPI's trusted publisher for `slop-writer`, so adding jobs to it would
+# widen what an OIDC-capable workflow runs. This one mints no tokens.
+
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A second push to the same PR cancels the first — nothing here has side
+# effects worth finishing.
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The floor from requires-python, and the newest supported release.
+        # Nothing between them exercises a different code path, but the floor
+        # is where a 3.12+ idiom would slip in unnoticed.
+        python: ["3.11", "3.13"]
+    steps:
+      # Actions pinned to commit SHAs, matching publish.yaml. Bump the SHA and
+      # the trailing version comment together.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python }}
+
+      # No --locked / --frozen: uv.lock is gitignored (this is a library, not
+      # an application), so CI resolves against the index every run. That is
+      # the point — a telethon or mistune release that breaks us shows up here
+      # rather than in a user's install.
+      #
+      # `uv run` installs the project editable, so the suite exercises this
+      # checkout; tests/test_packaging.py asserts it rather than assuming it.
+      - name: Run the suite
+        run: uv run --group dev pytest
+
+  wheel:
+    # The claim in pyproject.toml is that a PEP 735 dependency group never
+    # reaches wheel metadata. Asserted against a real build rather than
+    # trusted, because the failure is invisible: pytest would simply become a
+    # runtime dependency of everyone who installs slop-writer.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+
+      - name: Build
+        run: uv build --no-sources
+
+      - name: Dev dependencies must not reach the wheel
+        run: |
+          python - <<'PY'
+          import glob, sys, zipfile
+
+          wheel = glob.glob("dist/*.whl")[0]
+          with zipfile.ZipFile(wheel) as z:
+              meta = next(n for n in z.namelist() if n.endswith("METADATA"))
+              text = z.read(meta).decode()
+              names = z.namelist()
+
+          requires = sorted(
+              line for line in text.splitlines()
+              if line.startswith(("Requires-Dist", "Provides-Extra"))
+          )
+          print(wheel, *requires, sep="\n  ")
+
+          bad = [line for line in requires if "pytest" in line]
+          if bad:
+              sys.exit(f"::error::dev dependency leaked into the wheel: {bad}")
+          if any(n.startswith("tests/") for n in names):
+              sys.exit("::error::tests/ was packaged into the wheel")
+          PY
+
+  schema-doc:
+    # Not a pytest test: this guards a document in skills/, which the package
+    # does not ship, and its PEP-723 header pins slop-writer to this checkout
+    # editable — a different resolution from the suite's. Same push/PR trigger,
+    # separate subject.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+
+      - name: references/schema.md must match SCHEMA
+        run: uv run tools/check_schema_doc.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,10 +25,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The floor from requires-python, and the newest supported release.
-        # Nothing between them exercises a different code path, but the floor
-        # is where a 3.12+ idiom would slip in unnoticed.
-        python: ["3.11", "3.13"]
+        # Every CPython from the requires-python floor up to the newest stable
+        # release — the range a `pip install slop-writer` can actually land on.
+        # The floor is where a 3.12+ idiom would slip in unnoticed; the ceiling
+        # is where a dependency stops working before users hit it. Add the next
+        # version when it goes final and drop the floor only by moving
+        # requires-python, which is a release decision, not a CI one.
+        # No beta (3.15 is at b4 today): a red X on an unreleased interpreter
+        # says nothing about what we ship.
+        python: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       # Actions pinned to commit SHAs, matching publish.yaml. Bump the SHA and
       # the trailing version comment together.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,11 +73,38 @@ drives. Distributed via the `skills` npm CLI (`npx skills@latest add ...`).
   - `markdown.py` — `publish.py` only: walks mistune's Markdown AST straight
     to Telethon `MessageEntity` objects (no HTML, no sulguk). Tables render as
     monospace `pre`; UTF-16 offset accounting lives here.
+- `tests/` — the package suite. **`uv run pytest`** (from the repo root; `uv`
+  installs the project editable, so it exercises the working tree). It targets
+  `slop_writer.*` functions and their return shapes, **never** a script's
+  stdout or exit code — the CLI is scheduled to stop being the exercise
+  surface, so a test that asserted on rendered Markdown would be deleted by
+  the MCP move. Where the #15 vocabulary names a failure, assert on
+  `SlopWriterError.code`, not on the message.
+  - `factories.py` holds the faking policy: **messages are real Telethon TL
+    objects** (`complete_albums`/`scan_group` gate on `isinstance`, and
+    Telethon is already a hard dependency), **the client is hand-faked**.
+    Recorded fixtures were rejected — they pin a wire format the `<2` pin
+    already expects to move. One quirk the factories hide: `Message.text` is a
+    property returning `None` until assigned, and every `msg.text or ""` in
+    the package depends on it.
+  - Nothing in the suite touches a Telegram session, `.tg-analytic/`, or the
+    network. Live runs stay the acceptance step; they are no longer the only
+    one.
+  - pytest lives in a PEP 735 `[dependency-groups] dev` — never an extra, so
+    it cannot reach a user's install. CI asserts that against the built wheel.
+  - `asyncio.run` via `tests/conftest.py:run`, not pytest-asyncio: four async
+    functions don't justify a plugin whose `asyncio_mode` silently skips tests.
+- `.github/workflows/test.yaml` — push/PR CI: the suite on 3.11 + 3.13, the
+  wheel-metadata guard, and `check_schema_doc.py`. Deliberately **not** part of
+  `publish.yaml`, whose *filename* is bound to PyPI's trusted publisher.
 - `tools/check_schema_doc.py` — **dev-only** drift guard, kept *outside* the
   skill so it isn't shipped to users; run after editing `SCHEMA` or
   `references/schema.md`. Its PEP-723 header pins `slop-writer` to *this
   checkout* (`[tool.uv.sources]`, editable), never to the released version —
   a guard reading the published schema would pass while the tree disagrees.
+  It stays a standalone script rather than becoming a test: its subject is a
+  document under `skills/` that the package doesn't ship, and its editable pin
+  is a different resolution from the suite's. CI runs it as its own step.
 - `.tg-analytic/` — **runtime state at the project root** (cwd), gitignored:
   `.env`, `session.session`, one `<channel>.db` per channel, `media/`. The
   **CLIs** anchor this on `Path.cwd()` (`PROJECT_ROOT` at the top of each

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,19 @@ Issues = "https://github.com/Lancetnik/slop-writer/issues"
 [build-system]
 requires = ["uv_build>=0.12.3,<0.13.0"]
 build-backend = "uv_build"
+
+# PEP 735, not [project.optional-dependencies]: a dependency group is a
+# development-time concept the build backend never writes into wheel metadata,
+# so pytest cannot reach a user who installs `slop-writer`. An extra would.
+# CI asserts this against the built wheel rather than trusting the claim.
+[dependency-groups]
+dev = ["pytest>=8,<9"]
+
+[tool.pytest.ini_options]
+# The suite must exercise *this checkout*, never the released package — the
+# same trap tools/check_schema_doc.py pins its own dependency against. `uv run
+# pytest` installs the project editable, and tests/test_packaging.py asserts
+# the result, so a stale wheel fails loudly instead of passing quietly.
+testpaths = ["tests"]
+addopts = "--strict-markers --strict-config"
+

--- a/src/slop_writer/__init__.py
+++ b/src/slop_writer/__init__.py
@@ -9,9 +9,10 @@ Nothing is re-exported here on purpose. Import the module you need:
     from slop_writer.group import classify_service_message
 
 A star-shaped `__init__` would make `import slop_writer.db` drag Telethon and
-mistune in behind it, and the Telegram-free half of this package — the schema,
-the SQL helpers, the group classification — is exactly what a query tool or a
-test wants without a client.
+mistune in behind it, and the Telegram-free half of this package — `db`,
+`query` and `errors` — is exactly what a query tool or a test wants without a
+client. (`group` used to belong to that set; it gave up the property in 0.2.0
+when the package settled on one flat dependency set.)
 
 `__version__` is read from the installed distribution metadata rather than
 written here, so `pyproject.toml` stays the single place a version is declared.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+"""Makes `tests` a package so modules can share `factories`/`conftest` by
+relative import — and so `tests.factories` can never shadow a real module on
+sys.path."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+"""Shared fixtures.
+
+Deliberately thin: no network, no session, no `.tg-analytic/`. Everything a
+test needs is either an in-memory SQLite DB or a tmp_path the test owns.
+"""
+
+import asyncio
+import sqlite3
+
+import pytest
+
+from slop_writer.db import SCHEMA
+
+
+def run(coro):
+    """Drive one coroutine to completion.
+
+    Used instead of pytest-asyncio: four async functions in the whole suite
+    (`complete_albums` and friends) do not justify a plugin whose `asyncio_mode`
+    setting is a standing source of "tests silently skipped" reports.
+    """
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def conn():
+    """An in-memory DB with `SCHEMA` applied and nothing else.
+
+    No FTS and no `open_db`, so a test of `heal_album_phantoms` exercises the
+    healer rather than the open path that also calls it.
+    """
+    c = sqlite3.connect(":memory:")
+    c.executescript(SCHEMA)
+    yield c
+    c.close()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,180 @@
+"""Test doubles for the Telegram side.
+
+The split here is the whole faking policy, and it is not the binary the
+ticket posed ("hand-rolled fake vs recorded fixtures"):
+
+* **Messages are real Telethon TL objects.** `complete_albums` and
+  `scan_group` gate on `isinstance(m, Message)` / `MessageService`, so a
+  hand-rolled stand-in would either have to subclass the real type anyway or
+  make the test vacuous. Telethon is already a hard dependency, so building
+  the real thing costs nothing. The one quirk the factories hide: `Message.text`
+  is a *property* that returns None until a client is attached — the setter
+  fills `message`/`entities` directly, which is what `_msg` below uses. Every
+  `msg.text or ""` in the package depends on it.
+* **The client is faked**, by hand, exposing only the coroutines the unit
+  under test actually awaits. This is the network boundary, and it is the one
+  place recorded fixtures were the alternative — rejected because a recording
+  pins Telethon's wire format, and the dependency pin (`telethon>=1.36,<2`)
+  already says a major-version move is expected.
+
+No fixture here needs a session, credentials, or a DB under `.tg-analytic/`.
+"""
+
+from datetime import UTC, datetime
+
+from telethon.tl.types import (
+    Message,
+    MessageFwdHeader,
+    MessageMediaPhoto,
+    MessageReactions,
+    MessageReplies,
+    MessageReplyHeader,
+    MessageService,
+    PeerChannel,
+    PeerUser,
+    ReactionCount,
+    ReactionEmoji,
+    ReactionPaid,
+)
+
+# Fixed so nothing in the suite depends on wall-clock time.
+DATE = datetime(2026, 3, 1, 12, 0, tzinfo=UTC)
+CHANNEL_ID = 1001
+GROUP_ID = 2002
+
+
+def msg(
+    id: int,
+    *,
+    text: str = "",
+    grouped_id: int | None = None,
+    date: datetime | None = None,
+    media: object | None = None,
+    views: int | None = None,
+    forwards: int | None = None,
+    edit_date: datetime | None = None,
+    reply_to_msg_id: int | None = None,
+    reply_to_top_id: int | None = None,
+    fwd_channel_post: int | None = None,
+    fwd_channel_id: int | None = None,
+    reactions: int = 0,
+    stars: int = 0,
+    replies: int | None = None,
+    sender_id: int | None = None,
+) -> Message:
+    """A real `telethon.tl.types.Message` with only the fields the domain reads."""
+    reply = None
+    if reply_to_msg_id is not None or reply_to_top_id is not None:
+        reply = MessageReplyHeader(
+            reply_to_msg_id=reply_to_msg_id, reply_to_top_id=reply_to_top_id
+        )
+    fwd = None
+    if fwd_channel_post is not None or fwd_channel_id is not None:
+        fwd = MessageFwdHeader(
+            date=date or DATE,
+            from_id=PeerChannel(fwd_channel_id) if fwd_channel_id else None,
+            channel_post=fwd_channel_post,
+        )
+    counts = []
+    if reactions:
+        counts.append(ReactionCount(reaction=ReactionEmoji("🔥"), count=reactions))
+    if stars:
+        counts.append(ReactionCount(reaction=ReactionPaid(), count=stars))
+
+    m = Message(
+        id=id,
+        peer_id=PeerChannel(CHANNEL_ID),
+        date=date or DATE,
+        message="",
+        grouped_id=grouped_id,
+        media=media,
+        views=views,
+        forwards=forwards,
+        edit_date=edit_date,
+        reply_to=reply,
+        fwd_from=fwd,
+        reactions=MessageReactions(results=counts) if counts else None,
+        replies=(
+            MessageReplies(comments=True, replies=replies, replies_pts=0)
+            if replies is not None
+            else None
+        ),
+        from_id=PeerUser(sender_id) if sender_id is not None else None,
+    )
+    # Property, not a plain field — see the module docstring.
+    m.text = text
+    return m
+
+
+def service(
+    id: int,
+    action: object,
+    *,
+    sender_id: int | None = None,
+    date: datetime | None = None,
+) -> MessageService:
+    """A real `MessageService`; `sender_id` is the actor, `None` = no actor."""
+    return MessageService(
+        id=id,
+        peer_id=PeerChannel(GROUP_ID),
+        date=date or DATE,
+        action=action,
+        from_id=PeerUser(sender_id) if sender_id is not None else None,
+    )
+
+
+def photo() -> MessageMediaPhoto:
+    """Enough of a photo for `messages.media_type` to say "photo"."""
+    return MessageMediaPhoto(photo=None)
+
+
+class AdminLogEvent:
+    """Duck-typed admin-log event.
+
+    Faked rather than built for real: `classify_admin_log_event` dispatches on
+    `type(action).__name__` and reads everything through `getattr`, so the
+    plain object *is* the shape the function was written against. Constructing
+    a real `ChannelAdminLogEvent` would add required fields the code never
+    looks at.
+    """
+
+    def __init__(self, id: int, action: object, *, user_id: int | None = None,
+                 date: datetime | None = None) -> None:
+        self.id = id
+        self.action = action
+        self.user_id = user_id
+        self.date = date or DATE
+
+
+class Named:
+    """An action object identified only by its class name.
+
+    `Named("ChannelAdminLogEventActionParticipantJoin")` classifies exactly as
+    the Telethon type would, because the name is all the dispatch reads.
+    """
+
+    def __new__(cls, name: str, **fields):
+        obj = super().__new__(type(name, (cls,), {}))
+        obj.__dict__.update(fields)
+        return obj
+
+    def __init__(self, name: str, **fields) -> None:  # noqa: D107 - see __new__
+        pass
+
+
+class FakeClient:
+    """Only `get_messages`, which is all `complete_albums` awaits.
+
+    `responses` maps a requested-id tuple to what Telegram returns; anything
+    unmapped comes back as a list of Nones, which is how the real API reports
+    ids that do not exist. `calls` records every request so a test can assert
+    that no round-trip happened at all.
+    """
+
+    def __init__(self, responses: dict[tuple[int, ...], list] | None = None) -> None:
+        self.responses = responses or {}
+        self.calls: list[list[int]] = []
+
+    async def get_messages(self, entity, ids=None):
+        self.calls.append(list(ids))
+        return self.responses.get(tuple(ids), [None] * len(ids))

--- a/tests/test_albums.py
+++ b/tests/test_albums.py
@@ -1,0 +1,295 @@
+"""The album invariant: one album = one `posts` row.
+
+This is the reason the suite exists. The phantom bug was silent — Telegram
+reports views and forwards on *every* album member, so an extra row carried
+plausible numbers and every SUM/AVG over `posts` counted the album twice.
+Both halves are covered here: `complete_albums` stops new phantoms being
+written, `heal_album_phantoms` clears the ones already on disk.
+"""
+
+import pytest
+
+from slop_writer.db import heal_album_phantoms
+from slop_writer.scrape import ALBUM_MAX_ITEMS, complete_albums
+
+from .conftest import run
+from .factories import FakeClient, msg
+
+# --------------------------------------------------------------------------
+# heal_album_phantoms — the rows already in the DB
+# --------------------------------------------------------------------------
+
+
+def add_post(conn, post_id, *, text="", grouped_id=None):
+    conn.execute(
+        "INSERT INTO posts (id, link, date, text, grouped_id) VALUES (?, ?, ?, ?, ?)",
+        (post_id, f"https://t.me/c/1/{post_id}", "2026-03-01T12:00:00+00:00",
+         text, grouped_id),
+    )
+
+
+def add_metrics(conn, post_id, views=100):
+    conn.execute(
+        "INSERT INTO post_metrics (post_id, scrape_date, views) VALUES (?, ?, ?)",
+        (post_id, "2026-03-01T12:00:00+00:00", views),
+    )
+
+
+def add_attachment(conn, post_id, attachment_id):
+    conn.execute(
+        "INSERT INTO post_attachments (post_id, attachment_id, link, media_type)"
+        " VALUES (?, ?, ?, 'photo')",
+        (post_id, attachment_id, f"https://t.me/c/1/{attachment_id}"),
+    )
+
+
+def add_share(conn, post_id, forwarder="https://t.me/other"):
+    conn.execute(
+        "INSERT INTO public_shares (post_id, forwarder_link, msg_link, first_seen)"
+        " VALUES (?, ?, ?, ?)",
+        (post_id, forwarder, f"{forwarder}/9", "2026-03-01T12:00:00+00:00"),
+    )
+
+
+def add_comment(conn, comment_id, thread_post_id):
+    conn.execute(
+        "INSERT INTO group_messages (id, date, text, user_id, thread_post_id,"
+        " is_thread_root) VALUES (?, ?, 'nice', 7, ?, 0)",
+        (comment_id, "2026-03-01T12:05:00+00:00", thread_post_id),
+    )
+
+
+def post_ids(conn):
+    return [r[0] for r in conn.execute("SELECT id FROM posts ORDER BY id")]
+
+
+def test_phantom_collapses_onto_the_caption_carrier(conn):
+    """The classic shape: a window that started inside an album left the
+    captionless member behind as a post of its own."""
+    add_post(conn, 10, text="", grouped_id=555)          # the phantom
+    add_post(conn, 11, text="the caption", grouped_id=555)  # the real post
+    add_metrics(conn, 10)
+    add_metrics(conn, 11)
+    add_attachment(conn, 10, 10)
+    add_attachment(conn, 11, 11)
+    add_share(conn, 10)
+    add_comment(conn, 900, thread_post_id=10)
+
+    heal_album_phantoms(conn)
+
+    assert post_ids(conn) == [11]
+    assert conn.execute(
+        "SELECT COUNT(*) FROM post_metrics WHERE post_id = 10"
+    ).fetchone()[0] == 0
+    assert conn.execute(
+        "SELECT COUNT(*) FROM post_attachments WHERE post_id = 10"
+    ).fetchone()[0] == 0
+    assert conn.execute(
+        "SELECT COUNT(*) FROM public_shares WHERE post_id = 10"
+    ).fetchone()[0] == 0
+    # The comment thread moves onto the surviving post rather than dangling.
+    assert conn.execute(
+        "SELECT thread_post_id FROM group_messages WHERE id = 900"
+    ).fetchone()[0] == 11
+    # The survivor keeps everything of its own.
+    assert conn.execute(
+        "SELECT COUNT(*) FROM post_metrics WHERE post_id = 11"
+    ).fetchone()[0] == 1
+
+
+def test_captionless_album_keeps_its_lowest_id(conn):
+    """No member carries text, so there is no caption carrier to prefer."""
+    add_post(conn, 20, text="", grouped_id=777)
+    add_post(conn, 21, text="", grouped_id=777)
+    add_post(conn, 22, text="", grouped_id=777)
+
+    heal_album_phantoms(conn)
+
+    assert post_ids(conn) == [20]
+
+
+def test_head_is_the_caption_carrier_even_when_it_is_not_first(conn):
+    add_post(conn, 30, text="", grouped_id=888)
+    add_post(conn, 31, text="", grouped_id=888)
+    add_post(conn, 32, text="caption arrives last", grouped_id=888)
+    add_comment(conn, 901, thread_post_id=30)
+
+    heal_album_phantoms(conn)
+
+    assert post_ids(conn) == [32]
+    assert conn.execute(
+        "SELECT thread_post_id FROM group_messages WHERE id = 901"
+    ).fetchone()[0] == 32
+
+
+def test_two_text_carrying_rows_are_left_alone(conn, caplog):
+    """Not the phantom pattern — two real posts that happen to share a
+    grouped_id are a shape this function must not guess about."""
+    add_post(conn, 40, text="first", grouped_id=999)
+    add_post(conn, 41, text="second", grouped_id=999)
+
+    with caplog.at_level("WARNING"):
+        heal_album_phantoms(conn)
+
+    assert post_ids(conn) == [40, 41]
+    assert "not the phantom pattern" in caplog.text
+
+
+def test_a_healthy_album_next_to_a_suspicious_one(conn):
+    """One album opting out must not stop the other from being healed."""
+    add_post(conn, 50, text="one", grouped_id=111)
+    add_post(conn, 51, text="two", grouped_id=111)     # left alone
+    add_post(conn, 60, text="", grouped_id=222)
+    add_post(conn, 61, text="caption", grouped_id=222)  # healed
+
+    heal_album_phantoms(conn)
+
+    assert post_ids(conn) == [50, 51, 61]
+
+
+def test_standalone_posts_and_single_member_albums_are_untouched(conn):
+    add_post(conn, 70, text="plain post", grouped_id=None)
+    add_post(conn, 71, text="", grouped_id=None)  # a captionless *photo* post
+    add_post(conn, 72, text="", grouped_id=333)   # only member of its album
+
+    heal_album_phantoms(conn)
+
+    assert post_ids(conn) == [70, 71, 72]
+
+
+def test_healing_is_idempotent(conn):
+    add_post(conn, 80, text="", grouped_id=444)
+    add_post(conn, 81, text="caption", grouped_id=444)
+
+    heal_album_phantoms(conn)
+    heal_album_phantoms(conn)
+
+    assert post_ids(conn) == [81]
+
+
+def test_empty_db_is_a_no_op(conn):
+    heal_album_phantoms(conn)
+    assert post_ids(conn) == []
+
+
+# --------------------------------------------------------------------------
+# complete_albums — stopping the phantom from being written in the first place
+# --------------------------------------------------------------------------
+
+
+def album(*ids, gid=555, caption_on=None):
+    """Album members as the pipeline sees them: exactly one carries text."""
+    return [
+        msg(i, grouped_id=gid, text="the caption" if i == caption_on else "")
+        for i in ids
+    ]
+
+
+def test_contiguous_window_with_neighbours_on_both_sides_skips_the_probe():
+    """The window itself proves the album whole: an id below and an id above
+    the group were fetched and are not members, so nothing can be missing."""
+    group = album(10, 11, caption_on=10)
+    client = FakeClient()
+
+    out = run(complete_albums(client, None, [group], {9, 10, 11, 12}, True))
+
+    assert client.calls == []
+    assert [m.id for m in out[0]] == [10, 11]
+
+
+def test_window_cut_at_the_low_edge_pulls_the_missing_members_back():
+    """The scrape started mid-album: ids 10 and 11 came back, the caption
+    carrier at 9 did not. Without this the captionless 10 becomes a post."""
+    group = album(10, 11)
+    head = msg(9, grouped_id=555, text="the caption")
+    room = ALBUM_MAX_ITEMS - 2
+    wanted = tuple(i for i in range(10 - room, 10) if i > 0)
+    client = FakeClient({wanted: [head if i == 9 else None for i in wanted]})
+
+    out = run(complete_albums(client, None, [group], {10, 11, 12}, True))
+
+    assert client.calls == [list(wanted)]
+    assert sorted(m.id for m in out[0]) == [9, 10, 11]
+
+
+def test_window_cut_at_the_high_edge_probes_upwards():
+    group = album(10, 11, caption_on=10)
+    tail = msg(12, grouped_id=555)
+    wanted = tuple(range(12, 12 + (ALBUM_MAX_ITEMS - 2)))
+    client = FakeClient({wanted: [tail if i == 12 else None for i in wanted]})
+
+    out = run(complete_albums(client, None, [group], {9, 10, 11}, True))
+
+    assert client.calls == [list(wanted)]
+    assert sorted(m.id for m in out[0]) == [10, 11, 12]
+
+
+def test_neighbours_of_another_album_are_not_absorbed():
+    """`get_messages` returns whatever sits at those ids; only members
+    carrying *this* album's grouped_id may join the group."""
+    group = album(10, 11)
+    stranger = msg(9, grouped_id=666, text="a different album")
+    wanted = tuple(i for i in range(10 - (ALBUM_MAX_ITEMS - 2), 10) if i > 0)
+    client = FakeClient({wanted: [stranger if i == 9 else None for i in wanted]})
+
+    out = run(complete_albums(client, None, [group], {10, 11, 12}, True))
+
+    assert sorted(m.id for m in out[0]) == [10, 11]
+
+
+def test_refresh_probes_both_sides_because_arbitrary_ids_prove_nothing():
+    """`window_contiguous=False` is the `refresh_posts` arm: ids 9 and 12 were
+    fetched, but a caller who asked for scattered ids has not shown that the
+    album stops there."""
+    group = album(10, 11, caption_on=10)
+    client = FakeClient()
+
+    run(complete_albums(client, None, [group], {9, 10, 11, 12}, False))
+
+    assert len(client.calls) == 1
+    asked = client.calls[0]
+    assert any(i < 10 for i in asked) and any(i > 11 for i in asked)
+    # Already-fetched ids are never re-requested.
+    assert 9 not in asked and 12 not in asked
+
+
+def test_probe_never_asks_for_a_non_positive_id():
+    """An album at the very start of a channel would otherwise request id 0
+    and below."""
+    group = album(2, 3, caption_on=2)
+    client = FakeClient()
+
+    run(complete_albums(client, None, [group], {2, 3}, True))
+
+    assert all(i > 0 for i in client.calls[0])
+    assert 1 in client.calls[0]
+
+
+def test_a_full_album_is_never_probed():
+    group = album(*range(10, 20), caption_on=10)
+    client = FakeClient()
+
+    out = run(complete_albums(client, None, [group], set(range(10, 20)), True))
+
+    assert client.calls == []
+    assert len(out[0]) == ALBUM_MAX_ITEMS
+
+
+def test_standalone_posts_are_passed_through():
+    group = [msg(10, text="a plain post")]
+    client = FakeClient()
+
+    out = run(complete_albums(client, None, [group], {10}, True))
+
+    assert client.calls == []
+    assert out == [group]
+
+
+@pytest.mark.parametrize("contiguous", [True, False])
+def test_groups_keep_their_order_and_count(contiguous):
+    groups = [[msg(1, text="a")], [msg(5, text="b")], [msg(9, text="c")]]
+    client = FakeClient()
+
+    out = run(complete_albums(client, None, groups, {1, 5, 9}, contiguous))
+
+    assert [g[0].id for g in out] == [1, 5, 9]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,192 @@
+"""Paths, the open path, and full-text search.
+
+`open_db` is the one function every command runs through, and it does more
+than open: it applies the schema, wires FTS best-effort, drops the legacy
+comment table and heals album phantoms. Each of those is a silent operation,
+which is exactly why they are asserted here.
+"""
+
+import sqlite3
+
+import pytest
+
+from slop_writer.db import SCHEMA, data_dir, db_path_for, env_path, open_db
+
+
+def test_paths_hang_off_the_project_root_the_caller_names(tmp_path):
+    assert data_dir(tmp_path).name == ".tg-analytic"
+    assert env_path(tmp_path) == tmp_path / ".tg-analytic" / ".env"
+
+
+@pytest.mark.parametrize(
+    "channel, filename",
+    [
+        ("@fastnewsdev", "fastnewsdev.db"),
+        ("fastnewsdev", "fastnewsdev.db"),
+        ("some/handle", "some_handle.db"),
+        ("@", "channel.db"),
+    ],
+)
+def test_one_db_file_per_channel(tmp_path, channel, filename):
+    assert db_path_for(tmp_path, channel).name == filename
+
+
+def test_open_creates_the_directory_and_every_table(tmp_path):
+    root = tmp_path / "nested" / "state"
+    conn = open_db(root, "@chan")
+    tables = {
+        r[0]
+        for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    conn.close()
+
+    assert root.is_dir()
+    assert {
+        "posts", "post_attachments", "post_metrics", "public_channels",
+        "public_shares", "subscribers", "subscriber_sources",
+        "group_messages", "group_events", "group_metrics",
+    } <= tables
+
+
+def test_opening_twice_is_safe(tmp_path):
+    open_db(tmp_path, "@chan").close()
+    conn = open_db(tmp_path, "@chan")
+    conn.execute("SELECT COUNT(*) FROM posts")
+    conn.close()
+
+
+def test_the_legacy_comment_table_is_dropped(tmp_path):
+    """Comments live in `group_messages` since docs/adr/0002; a DB from before
+    the merge self-heals rather than keeping two comment stores."""
+    path = db_path_for(tmp_path, "@chan")
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    legacy = sqlite3.connect(path)
+    legacy.executescript(SCHEMA)
+    legacy.execute("CREATE TABLE post_comments (id INTEGER PRIMARY KEY)")
+    legacy.commit()
+    legacy.close()
+
+    conn = open_db(tmp_path, "@chan")
+    found = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE name = 'post_comments'"
+    ).fetchone()
+    conn.close()
+    assert found is None
+
+
+def test_open_heals_phantoms_left_by_an_older_run(tmp_path):
+    path = db_path_for(tmp_path, "@chan")
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    old = sqlite3.connect(path)
+    old.executescript(SCHEMA)
+    old.executemany(
+        "INSERT INTO posts (id, text, grouped_id) VALUES (?, ?, ?)",
+        [(10, "", 555), (11, "caption", 555)],
+    )
+    old.commit()
+    old.close()
+
+    conn = open_db(tmp_path, "@chan")
+    ids = [r[0] for r in conn.execute("SELECT id FROM posts")]
+    conn.close()
+    assert ids == [11]
+
+
+# --------------------------------------------------------------------------
+# Full-text search (docs/adr/0004)
+# --------------------------------------------------------------------------
+
+def _has_fts5() -> bool:
+    """Ask the way `_ensure_fts` does — by trying, not by reading a pragma."""
+    try:
+        sqlite3.connect(":memory:").execute("CREATE VIRTUAL TABLE t USING fts5(x)")
+    except sqlite3.OperationalError:
+        return False
+    return True
+
+
+fts5 = pytest.mark.skipif(
+    not _has_fts5(),
+    reason="this SQLite build has no FTS5 — search is lost, scraping still works",
+)
+
+
+@fts5
+def test_a_new_post_becomes_searchable(tmp_path):
+    conn = open_db(tmp_path, "@chan")
+    conn.execute("INSERT INTO posts (id, text) VALUES (1, 'about telemetry')")
+    conn.commit()
+    hits = conn.execute(
+        "SELECT rowid FROM posts_fts WHERE posts_fts MATCH 'telem*'"
+    ).fetchall()
+    conn.close()
+    assert hits == [(1,)]
+
+
+@fts5
+def test_editing_and_deleting_keep_the_index_in_step(tmp_path):
+    conn = open_db(tmp_path, "@chan")
+    conn.execute("INSERT INTO posts (id, text) VALUES (1, 'original wording')")
+    conn.execute("UPDATE posts SET text = 'replacement wording' WHERE id = 1")
+    conn.commit()
+
+    def matches(term):
+        return conn.execute(
+            "SELECT rowid FROM posts_fts WHERE posts_fts MATCH ?", (term,)
+        ).fetchall()
+
+    assert matches("original") == []
+    assert matches("replacement") == [(1,)]
+
+    conn.execute("DELETE FROM posts WHERE id = 1")
+    conn.commit()
+    assert matches("replacement") == []
+    conn.close()
+
+
+@fts5
+def test_group_messages_are_searchable_too(tmp_path):
+    conn = open_db(tmp_path, "@chan")
+    conn.execute("INSERT INTO group_messages (id, text) VALUES (1, 'комментарий')")
+    conn.commit()
+    hits = conn.execute(
+        "SELECT rowid FROM gm_fts WHERE gm_fts MATCH 'комментар*'"
+    ).fetchall()
+    conn.close()
+    assert hits == [(1,)]
+
+
+@fts5
+def test_an_index_created_over_existing_rows_is_backfilled(tmp_path):
+    """A fresh external-content index starts empty and MATCH would silently
+    return nothing — the one-time 'rebuild' in `_ensure_fts` is what stops a
+    pre-FTS DB from looking like it has no posts."""
+    path = db_path_for(tmp_path, "@chan")
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    old = sqlite3.connect(path)
+    old.executescript(SCHEMA)  # no FTS_SCHEMA: this is a pre-adr/0004 DB
+    old.execute("INSERT INTO posts (id, text) VALUES (1, 'written before search')")
+    old.commit()
+    old.close()
+
+    conn = open_db(tmp_path, "@chan")
+    hits = conn.execute(
+        "SELECT rowid FROM posts_fts WHERE posts_fts MATCH 'written'"
+    ).fetchall()
+    conn.close()
+    assert hits == [(1,)]
+
+
+@fts5
+def test_reopening_does_not_double_count_an_already_backfilled_index(tmp_path):
+    conn = open_db(tmp_path, "@chan")
+    conn.execute("INSERT INTO posts (id, text) VALUES (1, 'once')")
+    conn.commit()
+    conn.close()
+
+    conn = open_db(tmp_path, "@chan")
+    hits = conn.execute(
+        "SELECT rowid FROM posts_fts WHERE posts_fts MATCH 'once'"
+    ).fetchall()
+    conn.close()
+    assert hits == [(1,)]

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,0 +1,343 @@
+"""Discussion-group classification and thread linkage.
+
+All of it is duck-typed over Telethon objects — dispatch on
+`type(action).__name__`, everything else through `getattr` — which is what
+makes plain stand-ins sufficient for the admin-log half (see
+`factories.Named`). The three-way actor split on `MessageActionChatDeleteUser`
+came from live data and is pinned here: calling a no-actor removal either
+'self' or 'removed' silently skews churn.
+"""
+
+from datetime import timedelta
+
+import pytest
+from telethon.tl.types import (
+    MessageActionChatAddUser,
+    MessageActionChatDeleteUser,
+    MessageActionChatJoinedByLink,
+    MessageActionChatJoinedByRequest,
+    MessageActionPinMessage,
+)
+
+from slop_writer.group import (
+    auto_forward_post_id,
+    classify_admin_log_event,
+    classify_service_message,
+    message_row,
+    thread_post_id_for,
+    unresolved_root_refs,
+    upsert_group_events,
+)
+
+from .factories import DATE, AdminLogEvent, Named, msg, photo, service
+
+CHANNEL = 1001
+
+
+def kinds(events):
+    return [(e.kind, e.via, e.user_id) for e in events]
+
+
+# --------------------------------------------------------------------------
+# Service messages
+# --------------------------------------------------------------------------
+
+
+def test_join_by_link():
+    ev = classify_service_message(
+        service(5, MessageActionChatJoinedByLink(inviter_id=99), sender_id=42)
+    )
+    assert kinds(ev) == [("join", "link", 42)]
+    assert ev[0].id == 5
+    assert ev[0].date == DATE.isoformat()
+
+
+def test_join_by_request():
+    ev = classify_service_message(
+        service(6, MessageActionChatJoinedByRequest(), sender_id=42)
+    )
+    assert kinds(ev) == [("join", "request", 42)]
+
+
+def test_one_add_user_message_can_carry_several_users():
+    """This is why `group_events`' primary key is (id, user_id)."""
+    ev = classify_service_message(
+        service(7, MessageActionChatAddUser(users=[1, 2, 3]), sender_id=1)
+    )
+    assert kinds(ev) == [
+        ("join", "added", 1),
+        ("join", "added", 2),
+        ("join", "added", 3),
+    ]
+    assert {e.id for e in ev} == {7}
+
+
+def test_a_self_join_via_the_button_looks_like_adding_yourself():
+    ev = classify_service_message(
+        service(8, MessageActionChatAddUser(users=[42]), sender_id=42)
+    )
+    assert kinds(ev) == [("join", "added", 42)]
+
+
+def test_leave_by_the_member_themselves():
+    ev = classify_service_message(
+        service(9, MessageActionChatDeleteUser(user_id=42), sender_id=42)
+    )
+    assert kinds(ev) == [("leave", "self", 42)]
+
+
+def test_leave_at_someone_elses_hand_is_a_removal():
+    ev = classify_service_message(
+        service(10, MessageActionChatDeleteUser(user_id=42), sender_id=7)
+    )
+    assert kinds(ev) == [("leave", "removed", 42)]
+
+
+def test_a_removal_with_no_actor_is_neither():
+    """Telegram auto-removing a deleted account leaves no sender. Bucketing
+    it as 'self' or 'removed' would skew churn either way, so it gets its
+    own value."""
+    ev = classify_service_message(
+        service(11, MessageActionChatDeleteUser(user_id=42), sender_id=None)
+    )
+    assert kinds(ev) == [("leave", "unknown", 42)]
+
+
+def test_non_membership_service_messages_yield_nothing():
+    assert classify_service_message(service(12, MessageActionPinMessage())) == []
+
+
+def test_a_message_without_an_action_yields_nothing():
+    assert classify_service_message(msg(13, text="ordinary")) == []
+
+
+# --------------------------------------------------------------------------
+# Admin log
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "action_name, expected",
+    [
+        ("ChannelAdminLogEventActionParticipantJoin", ("join", "added")),
+        ("ChannelAdminLogEventActionParticipantJoinByInvite", ("join", "link")),
+        ("ChannelAdminLogEventActionParticipantJoinByRequest", ("join", "request")),
+        ("ChannelAdminLogEventActionParticipantLeave", ("leave", "self")),
+    ],
+)
+def test_actor_shaped_admin_events(action_name, expected):
+    ev = classify_admin_log_event(
+        AdminLogEvent(9_000_001, Named(action_name), user_id=42)
+    )
+    assert kinds(ev) == [(*expected, 42)]
+    assert ev[0].id == 9_000_001
+
+
+def test_an_invite_credits_the_invited_participant_not_the_inviter():
+    action = Named(
+        "ChannelAdminLogEventActionParticipantInvite",
+        participant=Named("ChannelParticipant", user_id=42),
+    )
+    ev = classify_admin_log_event(AdminLogEvent(9_000_002, action, user_id=7))
+    assert kinds(ev) == [("join", "added", 42)]
+
+
+def test_an_invite_without_a_resolvable_participant_is_dropped():
+    action = Named("ChannelAdminLogEventActionParticipantInvite", participant=None)
+    assert classify_admin_log_event(AdminLogEvent(9_000_003, action)) == []
+
+
+def test_a_ban_that_ejects_the_member_is_a_leave():
+    action = Named(
+        "ChannelAdminLogEventActionParticipantToggleBan",
+        new_participant=Named(
+            "ChannelParticipantBanned", left=True, peer=Named("PeerUser", user_id=42)
+        ),
+    )
+    ev = classify_admin_log_event(AdminLogEvent(9_000_004, action))
+    assert kinds(ev) == [("leave", "removed", 42)]
+
+
+def test_a_rights_only_restriction_is_not_a_leave():
+    """The member is still in the group; counting it as churn would be wrong."""
+    action = Named(
+        "ChannelAdminLogEventActionParticipantToggleBan",
+        new_participant=Named(
+            "ChannelParticipantBanned", left=False, peer=Named("PeerUser", user_id=42)
+        ),
+    )
+    assert classify_admin_log_event(AdminLogEvent(9_000_005, action)) == []
+
+
+def test_unrelated_admin_events_yield_nothing():
+    assert classify_admin_log_event(
+        AdminLogEvent(9_000_006, Named("ChannelAdminLogEventActionChangeTitle"))
+    ) == []
+    assert classify_admin_log_event(AdminLogEvent(9_000_007, None)) == []
+
+
+# --------------------------------------------------------------------------
+# Thread roots
+# --------------------------------------------------------------------------
+
+
+def test_an_auto_forward_of_our_channel_is_a_root():
+    m = msg(100, fwd_channel_post=42, fwd_channel_id=CHANNEL)
+    assert auto_forward_post_id(m, CHANNEL) == 42
+
+
+def test_a_forward_of_someone_elses_channel_is_not_a_root():
+    m = msg(100, fwd_channel_post=42, fwd_channel_id=9999)
+    assert auto_forward_post_id(m, CHANNEL) is None
+
+
+def test_a_standalone_group_has_no_roots_at_all():
+    m = msg(100, fwd_channel_post=42, fwd_channel_id=CHANNEL)
+    assert auto_forward_post_id(m, None) is None
+
+
+def test_a_plain_message_is_not_a_root():
+    assert auto_forward_post_id(msg(100, text="hi"), CHANNEL) is None
+
+
+def test_a_forward_without_a_channel_post_is_not_a_root():
+    m = msg(100, fwd_channel_id=CHANNEL)
+    assert auto_forward_post_id(m, CHANNEL) is None
+
+
+# --------------------------------------------------------------------------
+# Thread linkage
+# --------------------------------------------------------------------------
+
+
+ROOTS = {200: 42}  # group-side root id -> channel post id
+
+
+def test_a_direct_comment_carries_the_head_in_reply_to_msg_id():
+    assert thread_post_id_for(msg(201, reply_to_msg_id=200), ROOTS) == 42
+
+
+def test_a_nested_reply_carries_the_head_in_top_id():
+    """reply_to_msg_id points at the sibling comment; only top_id names the
+    thread."""
+    m = msg(202, reply_to_msg_id=201, reply_to_top_id=200)
+    assert thread_post_id_for(m, ROOTS) == 42
+
+
+def test_top_level_chatter_belongs_to_no_thread():
+    assert thread_post_id_for(msg(203, text="hello"), ROOTS) is None
+
+
+def test_a_reply_under_an_unknown_head_is_unresolved_not_wrong():
+    assert thread_post_id_for(msg(204, reply_to_msg_id=999), ROOTS) is None
+
+
+def test_unresolved_heads_are_collected_for_a_targeted_fetch():
+    msgs = [
+        msg(201, reply_to_msg_id=200),   # known root
+        msg(205, reply_to_msg_id=999),   # out-of-window root
+        msg(206, reply_to_top_id=888),   # out-of-window root, nested
+        msg(207, text="chatter"),        # no reply at all
+    ]
+    assert unresolved_root_refs(msgs, ROOTS) == {999, 888}
+
+
+def test_nothing_unresolved_when_every_head_is_known():
+    assert unresolved_root_refs([msg(201, reply_to_msg_id=200)], ROOTS) == set()
+
+
+# --------------------------------------------------------------------------
+# Row shapes
+# --------------------------------------------------------------------------
+
+
+def test_message_row_flattens_a_comment():
+    m = msg(
+        301,
+        text="nice post",
+        reply_to_msg_id=200,
+        reactions=3,
+        stars=7,
+        sender_id=42,
+        media=photo(),
+    )
+    row = message_row(m, thread_post=99, is_root=False)
+    assert row[0] == 301
+    assert row[1] == DATE.isoformat()
+    assert row[2] == "nice post"
+    assert row[6] == 200
+    assert row[7] == 99
+    assert row[8] == 0
+    # Paid reactions are folded into the same total the schema stores.
+    assert row[9] == 10
+    assert row[10] == "photo"
+
+
+def test_message_row_marks_a_root():
+    row = message_row(msg(302, text=""), thread_post=99, is_root=True)
+    assert row[8] == 1
+
+
+# --------------------------------------------------------------------------
+# Event writes
+# --------------------------------------------------------------------------
+
+
+def test_events_with_a_known_user_upsert_on_rescan(conn):
+    from slop_writer.group import GroupEvent
+
+    events = [GroupEvent(1, DATE.isoformat(), "join", "link", 42)]
+    upsert_group_events(conn, events, {42: ("Ann", "ann")})
+    upsert_group_events(conn, events, {42: ("Ann Renamed", "ann2")})
+
+    rows = conn.execute(
+        "SELECT id, kind, via, user_id, user_name, user_username, author"
+        " FROM group_events"
+    ).fetchall()
+    assert rows == [(1, "join", "link", 42, "Ann Renamed", "ann2", "ann2")]
+
+
+def test_events_with_an_unknown_user_do_not_pile_up(conn):
+    """SQLite treats NULLs in a composite PK as distinct, so ON CONFLICT
+    cannot dedupe these — the writer pre-deletes them instead. Without that,
+    every re-scan would add another copy of the same event."""
+    from slop_writer.group import GroupEvent
+
+    events = [GroupEvent(2, DATE.isoformat(), "leave", "unknown", None)]
+    upsert_group_events(conn, events, {})
+    upsert_group_events(conn, events, {})
+    upsert_group_events(conn, events, {})
+
+    assert conn.execute(
+        "SELECT COUNT(*) FROM group_events WHERE id = 2"
+    ).fetchone()[0] == 1
+
+
+def test_the_author_column_falls_back_through_username_name_then_id(conn):
+    from slop_writer.group import GroupEvent
+
+    upsert_group_events(
+        conn,
+        [
+            GroupEvent(10, DATE.isoformat(), "join", "link", 1),
+            GroupEvent(11, DATE.isoformat(), "join", "link", 2),
+            GroupEvent(12, DATE.isoformat(), "join", "link", 3),
+        ],
+        {1: ("Ann", "ann"), 2: ("Bob", None)},
+    )
+    authors = dict(conn.execute("SELECT id, author FROM group_events"))
+    assert authors == {10: "ann", 11: "Bob", 12: "3"}
+
+
+def test_add_user_events_sharing_an_id_all_land(conn):
+    from slop_writer.group import GroupEvent
+
+    date = (DATE + timedelta(seconds=1)).isoformat()
+    upsert_group_events(
+        conn,
+        [GroupEvent(20, date, "join", "added", uid) for uid in (1, 2, 3)],
+        {},
+    )
+    assert conn.execute(
+        "SELECT COUNT(*) FROM group_events WHERE id = 20"
+    ).fetchone()[0] == 3

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,277 @@
+"""Markdown -> (text, Telethon entities).
+
+UTF-16 offset accounting is ours by choice (docs/adr/0003 — no HTML hop, no
+sulguk), and until now it was verified only by looking at live posts. These are
+golden tests over the markup `references/markup.md` promises.
+
+Every assertion is on the *pair*: an offset is only correct relative to the
+text that came out with it, so checking entities without the text would pass
+on a body that renders wrong.
+"""
+
+import pytest
+
+from slop_writer.markdown import render
+
+
+def ents(markdown: str):
+    """(text, [(entity class name, offset, length)])."""
+    text, entities = render(markdown)
+    return text, [(type(e).__name__, e.offset, e.length) for e in entities]
+
+
+# --------------------------------------------------------------------------
+# Inline spans
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src, kind",
+    [
+        ("**bold**", "MessageEntityBold"),
+        ("__bold__", "MessageEntityBold"),
+        ("*italic*", "MessageEntityItalic"),
+        ("_italic_", "MessageEntityItalic"),
+        ("~~strike~~", "MessageEntityStrike"),
+        ("^^under^^", "MessageEntityUnderline"),
+        ("||spoil||", "MessageEntitySpoiler"),
+        ("`code`", "MessageEntityCode"),
+    ],
+)
+def test_each_span_covers_exactly_its_content(src, kind):
+    text, entities = ents(src)
+    assert entities == [(kind, 0, len(text))]
+    assert "*" not in text and "~" not in text and "|" not in text
+
+
+def test_a_span_inside_a_sentence_lands_on_the_right_offset():
+    text, entities = ents("say **this** loudly")
+    assert text == "say this loudly"
+    assert entities == [("MessageEntityBold", 4, 4)]
+
+
+def test_nested_spans_both_survive():
+    text, entities = ents("**bold with *italic* inside**")
+    assert text == "bold with italic inside"
+    assert ("MessageEntityBold", 0, 23) in entities
+    assert ("MessageEntityItalic", 10, 6) in entities
+
+
+def test_entities_are_sorted_by_offset_then_widest_first():
+    _, entities = ents("**a *b* c** and `d`")
+    offsets = [(o, -ln) for _, o, ln in entities]
+    assert offsets == sorted(offsets)
+
+
+def test_an_empty_span_emits_no_entity():
+    text, entities = ents("****")
+    assert entities == []
+
+
+# --------------------------------------------------------------------------
+# UTF-16 offsets — the reason this module exists
+# --------------------------------------------------------------------------
+
+
+def test_an_astral_emoji_counts_as_two_units():
+    """🚀 is one Python character but two UTF-16 code units, which is what
+    Telegram counts. Getting this wrong shifts every entity after it."""
+    text, entities = ents("🚀 **bold**")
+    assert text == "🚀 bold"
+    assert entities == [("MessageEntityBold", 3, 4)]
+
+
+def test_several_emoji_accumulate():
+    text, entities = ents("🚀🔥 **x**")
+    assert text == "🚀🔥 x"
+    assert entities == [("MessageEntityBold", 5, 1)]
+
+
+def test_a_bmp_emoji_counts_as_one():
+    """★ is inside the BMP — one unit, unlike 🚀."""
+    text, entities = ents("★ **x**")
+    assert text == "★ x"
+    assert entities == [("MessageEntityBold", 2, 1)]
+
+
+def test_emoji_inside_the_span_widen_it():
+    text, entities = ents("**🚀 go**")
+    assert text == "🚀 go"
+    assert entities == [("MessageEntityBold", 0, 5)]
+
+
+def test_cyrillic_counts_as_one_unit_each():
+    text, entities = ents("привет **мир**")
+    assert text == "привет мир"
+    assert entities == [("MessageEntityBold", 7, 3)]
+
+
+# --------------------------------------------------------------------------
+# Links
+# --------------------------------------------------------------------------
+
+
+def test_a_link_becomes_a_text_url_entity():
+    text, entities = render("see [the docs](https://example.com/x) now")
+    assert text == "see the docs now"
+    (e,) = entities
+    assert type(e).__name__ == "MessageEntityTextUrl"
+    assert (e.offset, e.length, e.url) == (4, 8, "https://example.com/x")
+
+
+def test_a_bare_url_keeps_its_own_text():
+    text, entities = render("go to https://example.com/x")
+    assert "https://example.com/x" in text
+    assert entities and entities[0].url == "https://example.com/x"
+
+
+def test_formatting_inside_a_link_survives():
+    text, entities = ents("[**bold link**](https://example.com)")
+    assert text == "bold link"
+    kinds = {k for k, _, _ in entities}
+    assert kinds == {"MessageEntityTextUrl", "MessageEntityBold"}
+
+
+# --------------------------------------------------------------------------
+# Blocks
+# --------------------------------------------------------------------------
+
+
+def test_a_heading_is_emulated_as_bold():
+    """Telegram has no heading entity."""
+    text, entities = ents("# Title\n\nbody")
+    assert text == "Title\n\nbody"
+    assert entities == [("MessageEntityBold", 0, 5)]
+
+
+def test_a_hashtag_line_stays_literal():
+    """The reason this project uses mistune rather than Python-Markdown:
+    `#tag` must not become an <h1>."""
+    text, entities = ents("post body\n\n#python #telegram")
+    assert text.endswith("#python #telegram")
+    assert entities == []
+
+
+def test_a_fenced_block_carries_its_language():
+    text, entities = render("```python\nprint(1)\n```")
+    assert text == "print(1)"
+    (e,) = entities
+    assert type(e).__name__ == "MessageEntityPre"
+    assert (e.offset, e.length, e.language) == (0, 8, "python")
+
+
+def test_a_fence_without_a_language_gets_an_empty_one():
+    _, entities = render("```\nplain\n```")
+    assert entities[0].language == ""
+
+
+def test_a_blockquote_wraps_its_whole_body():
+    text, entities = ents("> quoted line")
+    assert text == "quoted line"
+    assert entities == [("MessageEntityBlockquote", 0, 11)]
+
+
+def test_paragraphs_are_separated_by_a_blank_line():
+    text, _ = render("one\n\ntwo")
+    assert text == "one\n\ntwo"
+
+
+def test_a_soft_break_becomes_a_newline():
+    text, _ = render("one\ntwo")
+    assert text == "one\ntwo"
+
+
+# --------------------------------------------------------------------------
+# Lists
+# --------------------------------------------------------------------------
+
+
+def test_a_bullet_list_gets_bullets():
+    text, _ = render("- one\n- two")
+    assert text == "• one\n• two"
+
+
+def test_an_ordered_list_is_numbered():
+    text, _ = render("1. one\n2. two\n3. three")
+    assert text == "1. one\n2. two\n3. three"
+
+
+def test_an_ordered_list_honours_its_start():
+    text, _ = render("5. five\n6. six")
+    assert text.startswith("5. five\n6. six")
+
+
+def test_a_nested_list_is_indented():
+    text, _ = render("- outer\n  - inner")
+    assert "  • inner" in text
+
+
+def test_formatting_inside_a_list_item_keeps_its_offset():
+    text, entities = ents("- plain\n- **bold**")
+    assert text == "• plain\n• bold"
+    assert entities == [("MessageEntityBold", 10, 4)]
+
+
+def test_a_list_may_interrupt_a_paragraph():
+    """CommonMark-ish behaviour this project picked mistune for: no blank
+    line required before the list."""
+    text, _ = render("intro:\n- one\n- two")
+    assert "• one" in text and "• two" in text
+
+
+# --------------------------------------------------------------------------
+# Tables — Telegram has no table entity, so they become aligned monospace
+# --------------------------------------------------------------------------
+
+
+def test_a_table_becomes_one_pre_block():
+    src = "| a | bb |\n| --- | --- |\n| 1 | 2 |"
+    text, entities = render(src)
+    assert len(entities) == 1
+    assert type(entities[0]).__name__ == "MessageEntityPre"
+    assert entities[0].offset == 0
+    assert entities[0].length == len(text.encode("utf-16-le")) // 2
+
+
+def test_table_columns_are_padded_to_the_widest_cell():
+    src = "| a | b |\n| --- | --- |\n| longer | x |"
+    text, _ = render(src)
+    lines = text.split("\n")
+    assert lines[0] == "a      | b"
+    assert lines[1] == "-------+--"
+    assert lines[2] == "longer | x"
+
+
+def test_formatting_inside_a_cell_is_flattened():
+    src = "| a |\n| --- |\n| **bold** |"
+    text, entities = render(src)
+    assert "bold" in text and "**" not in text
+    assert [type(e).__name__ for e in entities] == ["MessageEntityPre"]
+
+
+# --------------------------------------------------------------------------
+# Degenerate input
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("src", ["", "   ", "\n\n\n"])
+def test_nothing_in_nothing_out(src):
+    assert render(src) == ("", [])
+
+
+def test_an_unclosed_spoiler_stays_literal():
+    text, entities = ents("||never closed")
+    assert "||never closed" == text
+    assert entities == []
+
+
+def test_no_entity_ever_runs_past_the_text():
+    text, entities = render(
+        "# Title\n\n**bold** and `code` and [link](https://e.com)\n\n"
+        "> quote 🚀\n\n- item\n\n```py\nx = 1\n```"
+    )
+    limit = len(text.encode("utf-16-le")) // 2
+    assert entities
+    for e in entities:
+        assert e.offset >= 0
+        assert e.offset + e.length <= limit

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,83 @@
+"""Guards on what the suite is actually testing.
+
+`tools/check_schema_doc.py` documents the trap these cover: a check that reads
+the *published* package passes while the working tree disagrees. The suite has
+the same failure mode, and it is invisible — every test would still pass, just
+against last release's code.
+"""
+
+import subprocess
+import sys
+import textwrap
+import tomllib
+from pathlib import Path
+
+import slop_writer
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def test_the_suite_runs_against_the_working_tree():
+    """`slop_writer` must resolve to `src/`, not to a wheel from the index."""
+    imported = Path(slop_writer.__file__).resolve().parent
+    assert imported == REPO / "src" / "slop_writer", (
+        f"tests are running against {imported}, not this checkout — "
+        "run them with `uv run pytest`, which installs the project editable"
+    )
+
+
+def test_the_library_still_declares_no_cli_dependency():
+    """`typer` left the package in 0.2.0 when the domain started raising
+    `SlopWriterError` instead of reporting its own failures. A library that
+    knows what a CLI is cannot be called by the MCP server."""
+    pyproject = tomllib.loads((REPO / "pyproject.toml").read_text())
+    deps = " ".join(pyproject["project"]["dependencies"]).lower()
+    assert "typer" not in deps
+    assert "click" not in deps
+
+
+def test_dev_dependencies_are_not_project_dependencies():
+    """pytest lives in a PEP 735 dependency group, which uv installs for
+    development and the build backend never writes into wheel metadata. The
+    packaging half of this is asserted in CI, which inspects the built
+    wheel — here we only stop it being added to the wrong table."""
+    pyproject = tomllib.loads((REPO / "pyproject.toml").read_text())
+    assert "pytest" not in " ".join(pyproject["project"]["dependencies"])
+    assert "optional-dependencies" not in pyproject["project"]
+    assert "pytest" in " ".join(pyproject["dependency-groups"]["dev"])
+
+
+def test_the_query_path_stays_importable_without_telethon():
+    """`db`, `query` and `errors` are the Telegram-free trio (#22): a caller
+    must be able to answer an analytics question without a client.
+
+    Run in a subprocess with Telethon blocked at the import hook, because the
+    property is about what the import actually reaches — this suite has
+    Telethon loaded from the first factory, so unloading it in-process would
+    only prove something about import order. It also holds `__init__.py` to
+    its own claim: a star-shaped one would drag Telethon in behind
+    `slop_writer.db`.
+    """
+    program = textwrap.dedent(
+        """
+        import sys
+
+        class Blocker:
+            def find_module(self, name, path=None):
+                return self.find_spec(name, path)
+
+            def find_spec(self, name, path=None, target=None):
+                if name == "telethon" or name.startswith("telethon."):
+                    raise AssertionError(f"reached Telethon via {name}")
+                return None
+
+        sys.meta_path.insert(0, Blocker())
+        import slop_writer.db, slop_writer.query, slop_writer.errors  # noqa: F401
+        print("clean")
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", program], capture_output=True, text=True
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "clean"

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,0 +1,258 @@
+"""The write surface's validation half — everything that runs before a session.
+
+`MIN_LEAD` is an agent-facing guard (docs/adr/0003): it exists so the agent
+driving this cannot schedule a post too soon, and it has no flag or env
+override by design. A silent break here is a post going out an hour early,
+which is why the floor gets its own tests rather than riding along with the
+rest of `prepare_schedule`.
+
+The check *order* in `prepare_schedule` is load-bearing too — a request with
+three problems must report the one nearest the front — so it is pinned by
+tests that make several things wrong at once.
+"""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from slop_writer.errors import SlopWriterError, UsageError
+from slop_writer.publish import (
+    MAX_ALBUM,
+    MIN_LEAD,
+    check_photos,
+    parse_schedule_time,
+    prepare_schedule,
+    render_body,
+)
+
+
+def iso_in(delta: timedelta, tz=UTC) -> str:
+    return (datetime.now(UTC) + delta).astimezone(tz).isoformat()
+
+
+SOON = timedelta(minutes=90)   # comfortably past the floor
+TOO_SOON = timedelta(minutes=30)
+
+
+# --------------------------------------------------------------------------
+# The floor itself
+# --------------------------------------------------------------------------
+
+
+def test_min_lead_is_one_hour():
+    """Pinned deliberately. adr/0003 makes this a constant with no override;
+    if it ever changes, that is a decision, not a refactor."""
+    assert MIN_LEAD == timedelta(hours=1)
+
+
+def test_a_time_past_the_floor_is_accepted():
+    when = parse_schedule_time(iso_in(SOON))
+    assert when.tzinfo is not None
+    assert when > datetime.now(UTC) + timedelta(minutes=59)
+
+
+def test_a_time_inside_the_floor_is_rejected():
+    with pytest.raises(SlopWriterError) as exc:
+        parse_schedule_time(iso_in(TOO_SOON))
+    assert exc.value.code == "INVALID_SCHEDULE_TIME"
+    assert "too soon" in exc.value.message
+    # A plain SlopWriterError, not UsageError: the arguments were well-formed,
+    # the request was refused. The CLIs' exit codes differ on exactly this.
+    assert not isinstance(exc.value, UsageError)
+    assert exc.value.exit_code == 1
+
+
+def test_a_past_time_is_rejected():
+    with pytest.raises(SlopWriterError):
+        parse_schedule_time(iso_in(timedelta(days=-1)))
+
+
+def test_the_error_names_the_earliest_acceptable_time():
+    with pytest.raises(SlopWriterError) as exc:
+        parse_schedule_time(iso_in(TOO_SOON))
+    assert "earliest" in exc.value.message
+
+
+# --------------------------------------------------------------------------
+# Parsing
+# --------------------------------------------------------------------------
+
+
+def test_z_suffix_is_accepted_as_utc():
+    when = parse_schedule_time(
+        (datetime.now(UTC) + SOON).replace(microsecond=0).isoformat()
+        .replace("+00:00", "Z")
+    )
+    assert when.utcoffset() == timedelta(0)
+
+
+def test_a_non_utc_offset_is_kept():
+    tz = timezone_plus(3)
+    when = parse_schedule_time(iso_in(SOON, tz))
+    assert when.utcoffset() == timedelta(hours=3)
+
+
+def timezone_plus(hours: int):
+    from datetime import timezone
+
+    return timezone(timedelta(hours=hours))
+
+
+def test_surrounding_whitespace_is_tolerated():
+    parse_schedule_time("  " + iso_in(SOON) + "  ")
+
+
+def test_a_naive_time_is_rejected():
+    """Guessing the timezone could place a published post an hour off and
+    silently defeat the floor."""
+    naive = (datetime.now(UTC) + SOON).replace(tzinfo=None).isoformat()
+    with pytest.raises(UsageError) as exc:
+        parse_schedule_time(naive)
+    assert exc.value.code == "INVALID_SCHEDULE_TIME"
+    assert "no UTC offset" in exc.value.message
+    assert exc.value.exit_code == 2
+
+
+@pytest.mark.parametrize(
+    "raw", ["tomorrow", "2026-13-45T99:00:00+03:00", "", "18:00"]
+)
+def test_unparseable_input_is_a_usage_error(raw):
+    with pytest.raises(UsageError) as exc:
+        parse_schedule_time(raw)
+    assert exc.value.code == "INVALID_SCHEDULE_TIME"
+
+
+# --------------------------------------------------------------------------
+# check_photos
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def images(tmp_path):
+    def make(name: str) -> str:
+        p = tmp_path / name
+        p.write_bytes(b"not really an image, and nothing here reads it")
+        return str(p)
+
+    return make
+
+
+def test_valid_photos_come_back_as_paths(images):
+    out = check_photos([images("a.jpg"), images("b.PNG"), images("c.webp")])
+    assert all(isinstance(p, Path) for p in out)
+    assert [p.name for p in out] == ["a.jpg", "b.PNG", "c.webp"]
+
+
+def test_extension_matching_is_case_insensitive(images):
+    check_photos([images("SHOUTING.JPEG")])
+
+
+def test_more_than_one_album_is_rejected(images):
+    photos = [images(f"{i}.jpg") for i in range(MAX_ALBUM + 1)]
+    with pytest.raises(UsageError) as exc:
+        check_photos(photos)
+    assert "at most 10" in exc.value.message
+
+
+def test_exactly_one_full_album_is_fine(images):
+    assert len(check_photos([images(f"{i}.jpg") for i in range(MAX_ALBUM)])) == 10
+
+
+def test_a_missing_file_is_rejected(tmp_path):
+    with pytest.raises(UsageError) as exc:
+        check_photos([str(tmp_path / "nope.jpg")])
+    assert "file not found" in exc.value.message
+
+
+def test_a_directory_is_not_a_photo(tmp_path):
+    with pytest.raises(UsageError):
+        check_photos([str(tmp_path)])
+
+
+def test_a_non_photo_extension_is_rejected_rather_than_sent_as_a_document(images):
+    with pytest.raises(UsageError) as exc:
+        check_photos([images("clip.gif")])
+    assert "document attachments" in exc.value.message
+
+
+# --------------------------------------------------------------------------
+# render_body
+# --------------------------------------------------------------------------
+
+
+def test_an_empty_body_is_an_error_by_default():
+    with pytest.raises(UsageError) as exc:
+        render_body("   \n\n  ", source="stdin")
+    assert "stdin renders to an empty post" in exc.value.message
+
+
+def test_an_empty_body_is_allowed_for_a_photo_post():
+    assert render_body("", allow_empty=True) == ("", [])
+
+
+def test_markup_that_renders_to_nothing_still_counts_as_empty():
+    with pytest.raises(UsageError):
+        render_body("<!-- just a comment -->\n")
+
+
+# --------------------------------------------------------------------------
+# prepare_schedule — the order of checks
+# --------------------------------------------------------------------------
+
+
+def test_a_valid_request_becomes_a_draft(images):
+    draft = prepare_schedule(
+        "**hello**", iso_in(SOON), photo_paths=[images("a.jpg")]
+    )
+    assert draft.text == "hello"
+    assert len(draft.entities) == 1
+    assert [p.name for p in draft.photos] == ["a.jpg"]
+    assert draft.caption_above is False
+
+
+def test_time_is_checked_before_photos_and_body(images):
+    """Three things wrong at once; the report names the cheapest and most
+    often wrong of them."""
+    with pytest.raises(SlopWriterError) as exc:
+        prepare_schedule("", iso_in(TOO_SOON), photo_paths=["missing.gif"])
+    assert "too soon" in exc.value.message
+
+
+def test_photos_are_checked_before_the_body():
+    with pytest.raises(UsageError) as exc:
+        prepare_schedule("", iso_in(SOON), photo_paths=["missing.jpg"])
+    assert "file not found" in exc.value.message
+
+
+def test_a_captionless_photo_post_is_valid(images):
+    draft = prepare_schedule("", iso_in(SOON), photo_paths=[images("a.jpg")])
+    assert draft.text == ""
+    assert draft.entities == []
+
+
+def test_a_text_post_still_needs_a_body():
+    with pytest.raises(UsageError) as exc:
+        prepare_schedule("", iso_in(SOON), body_source="--file 'draft.md'")
+    assert "--file 'draft.md' renders to an empty post" in exc.value.message
+
+
+def test_caption_above_without_photos_is_rejected():
+    with pytest.raises(UsageError) as exc:
+        prepare_schedule("body", iso_in(SOON), caption_above=True)
+    assert "only makes sense with --photo" in exc.value.message
+
+
+def test_caption_above_needs_something_to_place_above(images):
+    with pytest.raises(UsageError) as exc:
+        prepare_schedule(
+            "", iso_in(SOON), photo_paths=[images("a.jpg")], caption_above=True
+        )
+    assert "non-empty body" in exc.value.message
+
+
+def test_caption_above_survives_onto_the_draft(images):
+    draft = prepare_schedule(
+        "caption", iso_in(SOON), photo_paths=[images("a.jpg")], caption_above=True
+    )
+    assert draft.caption_above is True

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,162 @@
+"""The read-only guard and the query path.
+
+`validate_read_only` is a guard the agent's SQL runs through on every call, so
+it gets tests. The threat model is not malicious SQL (`?mode=ro` handles that)
+but a clear early error — which means the *shape* of the rejection matters as
+much as the fact of it, and `code` is what the MCP server will key off.
+"""
+
+import pytest
+
+from slop_writer.db import SCHEMA, db_path_for
+from slop_writer.errors import SlopWriterError
+from slop_writer.query import run_query, schema_listing, validate_read_only
+
+ACCEPTED = [
+    "SELECT 1",
+    "select id from posts",
+    "  \n SELECT id FROM posts \n ",
+    "WITH latest AS (SELECT MAX(id) FROM post_metrics) SELECT * FROM latest",
+    "with x as (select 1) select * from x",
+    "SELECT 1;",            # a single trailing semicolon is fine
+    "SELECT 1  ;  ",
+    "-- a leading comment\nSELECT 1",
+    "-- one\n-- two\nSELECT 1",
+    "/* block */ SELECT 1",
+    "/* multi\n   line */\nSELECT 1",
+    "-- mixed\n/* both kinds */ -- again\nSELECT 1",
+]
+
+REJECTED = [
+    "DELETE FROM posts",
+    "INSERT INTO posts (id) VALUES (1)",
+    "UPDATE posts SET text = ''",
+    "DROP TABLE posts",
+    "ATTACH DATABASE 'x.db' AS x",
+    "PRAGMA table_info(posts)",
+    "CREATE TABLE t (a)",
+    "VACUUM",
+    "EXPLAIN SELECT 1",     # not a SELECT/WITH first word
+    "",
+    "   ",
+    "-- only a comment\n",
+    "SELECT 1; DROP TABLE posts",
+    "SELECT 1; SELECT 2",
+    "-- sneaky\nSELECT 1; DELETE FROM posts;",
+]
+
+
+@pytest.mark.parametrize("sql", ACCEPTED)
+def test_accepted(sql):
+    validate_read_only(sql)
+
+
+@pytest.mark.parametrize("sql", REJECTED)
+def test_rejected(sql):
+    with pytest.raises(SlopWriterError) as exc:
+        validate_read_only(sql)
+    assert exc.value.code == "QUERY_REJECTED"
+
+
+def test_empty_query_names_itself_in_the_message():
+    with pytest.raises(SlopWriterError) as exc:
+        validate_read_only("")
+    assert "<empty>" in exc.value.message
+
+
+def test_multi_statement_says_so():
+    with pytest.raises(SlopWriterError) as exc:
+        validate_read_only("SELECT 1; DROP TABLE posts")
+    assert "multi-statement" in exc.value.message
+
+
+# --------------------------------------------------------------------------
+# run_query
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db(tmp_path):
+    """A real on-disk DB for `run_query`, which opens by path in `?mode=ro`."""
+    import sqlite3
+
+    path = db_path_for(tmp_path, "@fastnewsdev")
+    conn = sqlite3.connect(path)
+    conn.executescript(SCHEMA)
+    conn.execute(
+        "INSERT INTO posts (id, link, date, text) VALUES (1, 'l', 'd', 'hello')"
+    )
+    conn.execute(
+        "INSERT INTO posts (id, link, date, text) VALUES (2, 'l', 'd', 'world')"
+    )
+    conn.commit()
+    conn.close()
+    return tmp_path
+
+
+def test_returns_columns_and_every_row(db):
+    result = run_query("SELECT id, text FROM posts ORDER BY id", "@fastnewsdev", db)
+    assert result.columns == ["id", "text"]
+    assert result.rows == [(1, "hello"), (2, "world")]
+
+
+def test_channel_handle_resolves_with_or_without_the_at(db):
+    assert run_query("SELECT COUNT(*) FROM posts", "fastnewsdev", db).rows == [(2,)]
+
+
+def test_missing_database_is_no_data_not_a_crash(tmp_path):
+    with pytest.raises(SlopWriterError) as exc:
+        run_query("SELECT 1", "@never-scraped", tmp_path)
+    assert exc.value.code == "NO_DATA"
+    assert "Scrape @never-scraped first" in (exc.value.hint or "")
+
+
+def test_a_bad_column_carries_the_schema_back_as_the_hint(db):
+    """The listing rides on the error so the caller can fix its SQL in one
+    retry instead of guessing column names."""
+    with pytest.raises(SlopWriterError) as exc:
+        run_query("SELECT no_such_col FROM posts", "@fastnewsdev", db)
+    assert exc.value.code == "QUERY_REJECTED"
+    assert "Available tables/columns:" in (exc.value.hint or "")
+    assert "posts(" in exc.value.hint
+
+
+def test_a_syntax_error_gets_no_schema_dump(db):
+    """Only 'no such column/table' is worth a listing; anything else would
+    just bloat the error."""
+    with pytest.raises(SlopWriterError) as exc:
+        run_query("SELECT FROM WHERE", "@fastnewsdev", db)
+    assert exc.value.hint is None
+
+
+def test_writes_are_stopped_before_the_engine_sees_them(db):
+    with pytest.raises(SlopWriterError) as exc:
+        run_query("DELETE FROM posts", "@fastnewsdev", db)
+    assert exc.value.code == "QUERY_REJECTED"
+
+
+# --------------------------------------------------------------------------
+# schema_listing
+# --------------------------------------------------------------------------
+
+
+def test_listing_hides_fts_shadow_tables_but_keeps_the_queryable_ones(tmp_path):
+    from slop_writer.db import open_db
+
+    conn = open_db(tmp_path, "@chan")
+    listing = schema_listing(conn)
+    conn.close()
+
+    assert "posts_fts(" in listing
+    assert "gm_fts(" in listing
+    assert "posts_fts_data" not in listing
+    assert "posts_fts_idx" not in listing
+    assert "sqlite_" not in listing
+
+
+def test_listing_includes_generated_columns(conn):
+    """`author` is a generated column — invisible to PRAGMA table_info, and
+    exactly what a retrying query should be told about."""
+    listing = schema_listing(conn)
+    assert "author" in listing
+    assert "Full docs: references/schema.md" in listing


### PR DESCRIPTION
Closes #27.

Reverses *"no test suite in this repo by choice"*. #22 put the logic in
`slop_writer`, so for the first time it is exercisable without a CLI — and the
CLI is scheduled to stop being the exercise surface (#17, #18), so live runs
against a real channel can no longer be the only thing between a refactor and a
silently wrong `SUM`.

**180 tests, ~0.4s, no network.** Nothing here touches a Telegram session, a
real `.tg-analytic/`, or a script's stdout.

## The constraint that shaped it

The suite targets `slop_writer.*` functions and their **return shapes**, plus
`SlopWriterError.code` wherever the #15 vocabulary names the failure
(`QUERY_REJECTED`, `NO_DATA`, `INVALID_SCHEDULE_TIME`) — so #17 cannot silently
rename a code the skill's docs promise. Never a rendered summary, never an exit
code: a test asserting on Markdown is one #16 would delete.

## Faking: a split, not a binary

The ticket posed it as hand-rolled fakes *vs* recorded fixtures. The answer is
neither, wholesale:

- **Messages are real Telethon TL objects.** `complete_albums` and `scan_group`
  gate on `isinstance(m, Message)`, so a stand-in would either have to subclass
  the real type anyway or make the test vacuous — and Telethon is already a hard
  dependency, so building the real thing costs nothing. One quirk `factories.py`
  hides: `Message.text` is a *property* returning `None` until assigned, and
  every `msg.text or ""` in the package depends on it — including the album
  head-pick.
- **The client is hand-faked** at the network boundary. Recorded fixtures were
  rejected: they pin a wire format `telethon>=1.36,<2` already expects to move.
- Where the code genuinely duck-types (`classify_admin_log_event` dispatches on
  `type(action).__name__`, reads through `getattr`), the fixture is a plain
  named object — that *is* the shape the function was written against.

Consequence: `scrape.ingest` and `group.scan_group` are left **testable** rather
than live-run-only. Filed as #28.

## Mutation-checked, not just run

| Mutation | Result |
| --- | --- |
| album head-pick → "lowest id always" | 4 failures |
| `MIN_LEAD = timedelta(hours=0)` | 4 failures, incl. the test pinning the constant |
| `_u16len` → `len()` | 3 failures — the emoji cases |

## Coverage

| Area | Tests |
| --- | --- |
| `markdown.render` (UTF-16 offsets, tables, spoilers) | 41 |
| `query.validate_read_only` / `run_query` / `schema_listing` | 37 |
| `group` classification + row/event writes | 35 |
| `publish` validation (`MIN_LEAD`, check order, photos) | 31 |
| `db.heal_album_phantoms` + `scrape.complete_albums` | 18 |
| `db.open_db` + FTS | 14 |
| packaging guards | 4 |

Beyond the ticket's list, three things the code documented but nothing checked:
the NULL-`user_id` pre-delete in `upsert_group_events` (SQLite treats NULLs in a
composite PK as distinct, so re-scans would pile up), the one-time FTS
`'rebuild'` over an already-populated table, and the Telegram-free trio —
imported in a subprocess with Telethon blocked at the import hook, because this
suite loads Telethon from the first factory and an in-process check would only
prove something about import order. That last one caught `__init__.py` still
claiming `group` as Telegram-free; it gave that up in 0.2.0.

## Packaging and CI

- pytest in a **PEP 735 `[dependency-groups] dev`**, never an extra — the
  backend does not write it into wheel metadata. The `wheel` CI job asserts that
  against a real build rather than trusting it; the failure would be invisible
  otherwise.
- **New `test.yaml`**, deliberately not an addition to `publish.yaml`, whose
  *filename* is bound to PyPI's trusted publisher. No `--locked`/`--frozen`:
  `uv.lock` is gitignored because this is a library, so CI resolves against the
  index every run — a `telethon` or `mistune` release that breaks us surfaces
  here rather than in a user's install.
- `tools/check_schema_doc.py` **stays a standalone script** with its own CI step:
  its subject is a document under `skills/` the package doesn't ship, and its
  editable pin is a different resolution from the suite's.
- No pytest-asyncio — four async functions don't justify a plugin whose
  `asyncio_mode` silently skips tests.

## Run it

```
uv run pytest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)