### PR TITLE
fix(errors): give the last two vocabulary codes a raise site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,8 +138,11 @@ disk.
     and **statically over the package's own source** (`ast`, every `code=`
     literal). The static half exists because most raise sites need a Telegram
     session to reach, so `__init__`'s check otherwise fires only in a live
-    run. It also records the two codes no raise site names yet
-    (`MESSAGE_TOO_LONG`, `NOT_A_MEMBER`) so a third is a decision.
+    run. Its `UNREACHED_CODES` ledger is **empty** as of #35 — every code in
+    the vocabulary is named by some raise site — and it survives its emptiness
+    so that re-adding an unreachable code is an edit somebody justifies.
+    `test_tg.py` is the behavioural half for `resolve_peer`'s two codes: the
+    static scan proves a `code=` literal exists, not that the line runs.
   - Nothing in the suite touches a Telegram session, `.tg-analytic/`, or the
     network. Live runs stay the acceptance step; they are no longer the only
     one.
@@ -333,8 +336,24 @@ Scrape selection flags are mutually exclusive; default to `--latest N`
   `src/slop_writer/` prints an error or exits: it raises `SlopWriterError`
   (`UsageError` for exit 2) and the CLI turns that into stderr + an exit code.
   This is what lets the MCP server call the same function and build a JSON
-  payload instead. `code` is the #15 vocabulary, and is `None` at the raise
-  sites that vocabulary doesn't name yet.
+  payload instead. `code` is the #15 vocabulary, enforced at construction, and
+  every entry in it has a raise site (#35 closed the last two). It stays
+  `None`-able only for the boundary, which labels an unanticipated exception
+  `INTERNAL`.
+- **A refusal is not an absence.** `CANNOT_RESOLVE` means the handle names
+  nothing; `NOT_A_MEMBER` means Telegram confirmed the peer and refused this
+  account. They share a Telethon call and nothing else — one is fixed by
+  correcting the handle, the other by joining — so `resolve_peer` splits
+  `ChannelPrivateError` out, and the group scan classifies the three calls it
+  makes past `resolve_peer` (the linked group's entity, its `full_chat`, and
+  the history read, which can refuse after the other two succeeded). In the
+  linked-group branch a bare `ValueError` counts as membership too: the group's
+  id came from Telegram one call earlier, so it provably exists.
+- **`MESSAGE_TOO_LONG` comes from the network, by design.** The cap depends on
+  the account (1024 UTF-16 units for a caption, 2048 with Premium, 4096 for a
+  text post), so `publish.py` does not measure the body — it translates
+  Telethon's `MessageTooLongError` / `MediaCaptionTooLongError` in `_too_long`,
+  which is therefore the only place the code can be named.
 - **The domain uses a client, the entrypoint owns it.** The scrape and scan
   paths come in twins: `X_with_client(client, …)` does the work,
   `X(…, session_file)` is the same call with one `channel_session` wrapped

--- a/src/slop_writer/group.py
+++ b/src/slop_writer/group.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from sqlite3 import Connection
 
 from telethon import TelegramClient
+from telethon.errors import ChannelPrivateError
 from telethon.tl.functions.channels import GetAdminLogRequest, GetFullChannelRequest
 from telethon.tl.types import (
     ChannelAdminLogEventsFilter,
@@ -311,6 +312,23 @@ class GroupScanResult:
     threads: list[dict]
 
 
+def not_a_member(label: str, cause: Exception) -> SlopWriterError:
+    """The scan's membership failure, reported as one code (#35).
+
+    Membership is the group scans' entry requirement — `resolve_peer` names
+    `NOT_A_MEMBER` for the handles it resolves, and this covers the calls the
+    scan makes past it, where Telegram refuses the group rather than the
+    handle. The remedy is the same everywhere it fires, which is why it is one
+    code and not three."""
+    return SlopWriterError(
+        f"Cannot read {label}: {cause}",
+        hint="A group scan needs this account to be a member of the group — "
+        "membership, not admin rights. Join it (a channel's discussion group "
+        "is joinable from the comments under any post), then retry.",
+        code="NOT_A_MEMBER",
+    )
+
+
 async def resolve_group_target(
     client: TelegramClient, channel: str | None, group: str | None
 ) -> GroupTarget:
@@ -331,13 +349,24 @@ async def resolve_group_target(
                 "standalone group instead.",
                 code="NO_LINKED_GROUP",
             )
-        entity = await client.get_entity(PeerChannel(linked))
+        # `linked` came from Telegram a line ago, so the group provably exists:
+        # a failure to reach it here is about this account, never about the
+        # handle. That includes the bare ValueError Telethon raises when the
+        # group is absent from the session's entity cache — an account in the
+        # group has seen it.
+        try:
+            entity = await client.get_entity(PeerChannel(linked))
+        except (ValueError, ChannelPrivateError) as e:
+            raise not_a_member(f"{channel}'s discussion group", e) from None
         channel_id = ch_entity.id
     else:
         entity = await resolve_peer(client, group)
         channel_id = None
 
-    g_full = await client(GetFullChannelRequest(entity))
+    try:
+        g_full = await client(GetFullChannelRequest(entity))
+    except ChannelPrivateError as e:
+        raise not_a_member(channel or group or "the group", e) from None
     if group and g_full.full_chat.linked_chat_id:
         log.warning(
             "%s is the discussion group of a channel (id %d) - to get "
@@ -574,16 +603,23 @@ async def scan_group_with_client(
             "authenticated, scanning group %s (%s)",
             target.title or target.link, handle,
         )
-        raw = [
-            m
-            async for m in client.iter_messages(
-                target.entity,
-                limit=iter_limit,
-                reverse=reverse,
-                offset_id=iter_offset_id,
-                offset_date=iter_offset_date,
-            )
-        ]
+        # Resolving the group does not prove this account may read it: an
+        # entity Telegram handed over with the channel's `full_chat`, or one
+        # left in the session cache by an earlier membership, resolves fine and
+        # then refuses the history. So the read is classified too.
+        try:
+            raw = [
+                m
+                async for m in client.iter_messages(
+                    target.entity,
+                    limit=iter_limit,
+                    reverse=reverse,
+                    offset_id=iter_offset_id,
+                    offset_date=iter_offset_date,
+                )
+            ]
+        except ChannelPrivateError as e:
+            raise not_a_member(target.title or handle or "the group", e) from None
         log.info("fetched %d group messages", len(raw))
 
         service = [m for m in raw if isinstance(m, MessageService)]

--- a/src/slop_writer/publish.py
+++ b/src/slop_writer/publish.py
@@ -198,7 +198,12 @@ def _too_long(text: str, *, media: bool) -> SlopWriterError:
     Length is deliberately NOT checked client-side: the cap depends on the
     account (photo captions: 1024 UTF-16 units, 2048 with Premium; text
     posts: 4096) and Telegram is the authority — a hardcoded check would
-    wrongly block Premium accounts. Rejection leaves nothing queued/changed."""
+    wrongly block Premium accounts. Rejection leaves nothing queued/changed.
+
+    That division is also why this is the only place `MESSAGE_TOO_LONG` can be
+    named: the verdict arrives over the network, so the code attaches where
+    Telethon's error is translated rather than at a length check that would
+    have to guess the cap it is enforcing."""
     n = _utf16_len(text)
     if media:
         cap = "photo-caption cap (1024 UTF-16 units, 2048 with Telegram Premium)"
@@ -206,7 +211,11 @@ def _too_long(text: str, *, media: bool) -> SlopWriterError:
         cap = "text-post cap (4096 UTF-16 units)"
     return SlopWriterError(
         f"Telegram rejected the body: {n} UTF-16 units is over this account's "
-        f"{cap}. Shorten the body — nothing was queued or changed."
+        f"{cap}. Shorten the body — nothing was queued or changed.",
+        hint="Shorten the body and retry. A photo caption is capped far below "
+        "a text post, so sending the same body without photos also raises the "
+        "ceiling.",
+        code="MESSAGE_TOO_LONG",
     )
 
 

--- a/src/slop_writer/tg.py
+++ b/src/slop_writer/tg.py
@@ -123,19 +123,32 @@ async def resolve_peer(client: TelegramClient, channel: str):
 
     Handles resolving to a person are rejected: every command targets a
     channel or group, and reading (or posting into) someone's private chat
-    is out of scope by design."""
+    is out of scope by design.
+
+    Two failures, two codes. `ChannelPrivateError` is Telegram saying the peer
+    is real and this account may not see it — a different situation from a
+    handle that names nothing, and a different fix: join it, versus correct it.
+    They used to share `CANNOT_RESOLVE`, which told an agent holding a perfectly
+    good handle to go looking for a typo (#35)."""
     try:
         entity = await client.get_entity(channel)
+    except ChannelPrivateError as e:
+        raise SlopWriterError(
+            f"Cannot access {channel}: {e}",
+            hint="The handle is fine — this account is not in that channel or "
+            "group (or was removed from it). Join it, or ask its owner for "
+            "access, then retry.",
+            code="NOT_A_MEMBER",
+        ) from None
     except (
         ValueError,
         UsernameInvalidError,
         UsernameNotOccupiedError,
-        ChannelPrivateError,
     ) as e:
         raise SlopWriterError(
             f"Cannot resolve {channel}: {e}",
-            hint="Check the handle for typos, and that this account can see "
-            "the channel (join it, or ask for access).",
+            hint="Check the handle for typos. A private group also resolves "
+            "only for an account that has already seen it.",
             code="CANNOT_RESOLVE",
         ) from None
     if isinstance(entity, User):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -265,6 +265,15 @@ class FakeClient:
     * `full` / `forwards` / `admin_log` answer the three raw TL requests.
       `admin_log_error` makes the log raise instead, which is what a non-admin
       account gets.
+    * An **exception** stored in `entities` or `full` is raised instead of
+      returned. Telegram's refusals are answers, not absences: a peer this
+      account may not see comes back as `ChannelPrivateError`, and the code
+      that separates it from a bad handle (#35) is only reachable if the fake
+      can say so. `iter_error` does the same for the history read, which is
+      the failure a *resolvable* group still produces for a non-member.
+    * `send_error` makes `send_message` / `send_file` raise — how Telegram
+      reports a body over the cap, since this package deliberately does not
+      measure it.
 
     Every call is recorded so a test can assert a round-trip did *not* happen.
     """
@@ -279,6 +288,8 @@ class FakeClient:
         forwards: dict[int, list] | None = None,
         admin_log: list | None = None,
         admin_log_error: Exception | None = None,
+        iter_error: Exception | None = None,
+        send_error: Exception | None = None,
     ) -> None:
         self.messages = list(messages or [])
         self.comments = comments or {}
@@ -292,7 +303,10 @@ class FakeClient:
         self.forwards = forwards or {}
         self._admin_log = list(admin_log or [])
         self.admin_log_error = admin_log_error
+        self.iter_error = iter_error
+        self.send_error = send_error
 
+        self.sends: list[dict] = []               # send_message/send_file kwargs
         self.calls: list[list[int]] = []          # get_messages id lists
         self.iter_calls: list[dict] = []          # iter_messages kwargs
         self.entity_calls: list = []
@@ -317,6 +331,8 @@ class FakeClient:
                 "reply_to": reply_to,
             }
         )
+        if self.iter_error is not None:
+            raise self.iter_error
         if reply_to is not None:
             window = list(self.comments.get(reply_to, []))
         elif reverse:
@@ -341,7 +357,25 @@ class FakeClient:
         key = entity_key(peer)
         if key not in self.entities:
             raise ValueError(f"no entity for {key!r}")
-        return self.entities[key]
+        entity = self.entities[key]
+        if isinstance(entity, Exception):
+            raise entity
+        return entity
+
+    # -- writes -------------------------------------------------------------
+
+    async def send_message(self, entity, text, **kwargs):
+        self.sends.append({"entity": entity, "text": text, **kwargs})
+        if self.send_error is not None:
+            raise self.send_error
+        return msg(1000, text=text)
+
+    async def send_file(self, entity, files, **kwargs):
+        self.sends.append({"entity": entity, "files": files, **kwargs})
+        if self.send_error is not None:
+            raise self.send_error
+        sent = msg(1000, text=kwargs.get("caption") or "")
+        return [sent] if isinstance(files, list) else sent
 
     async def download_media(self, msg, file=None):
         """Writes the file for real: `download_photo` skips the download when
@@ -360,7 +394,10 @@ class FakeClient:
             key = entity_key(request.channel)
             if key not in self.full:
                 raise ValueError(f"no full-channel entry for {key!r}")
-            return self.full[key]
+            full = self.full[key]
+            if isinstance(full, Exception):
+                raise full
+            return full
         if name == "GetMessagePublicForwardsRequest":
             return PublicForwards(self.forwards.get(request.msg_id, []))
         if name == "GetAdminLogRequest":

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -22,18 +22,16 @@ import pytest
 import slop_writer
 from slop_writer.errors import ERROR_CODES, SlopWriterError, UsageError
 
-#: Vocabulary entries that no raise site names yet — see
-#: `test_every_code_is_reachable_from_some_raise_site`. Listed rather than
-#: tolerated so that adding a third is a decision someone makes on purpose.
-UNREACHED_CODES = {
-    # Telegram enforces the caption/body caps, not this package (adr/0003), so
-    # a too-long body comes back from Telethon and reaches the model as
-    # INTERNAL. The code is the shape of the fix, not a description of today.
-    "MESSAGE_TOO_LONG",
-    # The group scans do require membership, but the failure currently arrives
-    # as whatever Telethon raised rather than as this code.
-    "NOT_A_MEMBER",
-}
+#: Vocabulary entries that no raise site names — see
+#: `test_every_code_is_reachable_from_some_raise_site`.
+#:
+#: Empty as of #35, which closed the two that were here: `MESSAGE_TOO_LONG` now
+#: rides `publish._too_long`, and `NOT_A_MEMBER` splits Telegram's "you may not
+#: see this peer" out of `CANNOT_RESOLVE`. The set survives its own emptiness on
+#: purpose — it is where a *deliberately* unreachable code would be recorded
+#: with its reason, so re-adding one is an edit somebody has to justify rather
+#: than a green suite quietly widening the contract.
+UNREACHED_CODES: set[str] = set()
 
 
 def _package_sources() -> list[Path]:
@@ -135,8 +133,8 @@ def test_no_raise_site_names_a_code_outside_the_vocabulary():
 def test_every_code_is_reachable_from_some_raise_site():
     """A code nothing raises is a promise to the model that never comes true:
     it appears in the contract's closed set, and the model may branch on a
-    value it will never receive. The two exceptions are recorded above with
-    the reason each is still aspirational."""
+    value it will never receive. `UNREACHED_CODES` is the ledger of exceptions
+    and is empty — every code in the vocabulary is named somewhere."""
     unreached = set(ERROR_CODES) - set(_codes_named_in_source())
     assert unreached == UNREACHED_CODES
 

--- a/tests/test_group_scan.py
+++ b/tests/test_group_scan.py
@@ -9,6 +9,7 @@ taking a client instead of opening its own session.
 import sqlite3
 
 import pytest
+from telethon.errors import ChannelPrivateError
 from telethon.tl.types import MessageActionChatAddUser, MessageActionChatDeleteUser
 
 from slop_writer.db import db_path_for, open_db
@@ -108,6 +109,78 @@ def test_a_typo_creates_no_database(tmp_path):
 
     assert exc.value.code == "CANNOT_RESOLVE"
     assert list(tmp_path.iterdir()) == []
+
+
+# --------------------------------------------------------------------------
+# Membership — the requirement the tool descriptions state and the scan spent
+# three calls failing to name (#35)
+# --------------------------------------------------------------------------
+
+
+def test_a_linked_group_this_account_is_not_in_is_not_a_resolve_failure(tmp_path):
+    """The case the code was written for. The channel resolves, Telegram hands
+    over the discussion group's *id*, and then refuses the group itself — so
+    the handle is provably fine and only membership is missing."""
+    client = linked_client([])
+    client.entities[GROUP_ID] = ChannelPrivateError(None)
+
+    with pytest.raises(SlopWriterError) as exc:
+        scan(client, tmp_path)
+
+    assert exc.value.code == "NOT_A_MEMBER"
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_linked_group_missing_from_the_session_cache_reads_the_same_way(tmp_path):
+    """Telethon's answer for a peer it has no access hash for is a bare
+    `ValueError` — indistinguishable from a typo *in general*, but not here:
+    `linked_chat_id` came from Telegram one call earlier, so the group exists
+    and an account that were in it would have seen it."""
+    client = linked_client([])
+    del client.entities[GROUP_ID]
+
+    with pytest.raises(SlopWriterError) as exc:
+        scan(client, tmp_path)
+
+    assert exc.value.code == "NOT_A_MEMBER"
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_group_that_refuses_its_own_full_channel_is_a_membership_failure(tmp_path):
+    """`GetFullChannelRequest` on the group is the second call past
+    `resolve_peer`, and it can refuse where `get_entity` did not."""
+    client = linked_client([])
+    client.full[GROUP_ID] = ChannelPrivateError(None)
+
+    with pytest.raises(SlopWriterError) as exc:
+        scan(client, tmp_path)
+
+    assert exc.value.code == "NOT_A_MEMBER"
+
+
+def test_a_group_that_resolves_but_refuses_its_history_is_still_not_a_member(tmp_path):
+    """Resolving is not reading. An entity cached from an earlier membership
+    resolves fine and then refuses `iter_messages` — the third site, and the
+    only one that fires after `open_db`, so this one *does* leave the file."""
+    client = linked_client([], iter_error=ChannelPrivateError(None))
+
+    with pytest.raises(SlopWriterError) as exc:
+        scan(client, tmp_path)
+
+    assert exc.value.code == "NOT_A_MEMBER"
+
+
+def test_the_membership_failure_names_membership_and_not_admin_rights(tmp_path):
+    """The distinction the tool descriptions make ("requires membership in the
+    group (not admin)") has to survive into the error, or the agent reads it as
+    NOT_ADMIN and gives up on a group it could simply join."""
+    client = linked_client([])
+    client.entities[GROUP_ID] = ChannelPrivateError(None)
+
+    with pytest.raises(SlopWriterError) as exc:
+        scan(client, tmp_path)
+
+    assert "not admin rights" in (exc.value.hint or "")
 
 
 def test_a_standalone_group_reports_no_threads(tmp_path):

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -15,7 +15,9 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
+from telethon.errors import MediaCaptionTooLongError, MessageTooLongError
 
+from slop_writer import publish
 from slop_writer.errors import SlopWriterError, UsageError
 from slop_writer.publish import (
     MAX_ALBUM,
@@ -25,6 +27,9 @@ from slop_writer.publish import (
     prepare_schedule,
     render_body,
 )
+
+from .conftest import run
+from .factories import FakeClient, fake_session
 
 
 def iso_in(delta: timedelta, tz=UTC) -> str:
@@ -278,3 +283,82 @@ def test_caption_above_survives_onto_the_draft(images):
         "caption", iso_in(SOON), photo_paths=[images("a.jpg")], caption_above=True
     )
     assert draft.caption_above is True
+
+
+# --------------------------------------------------------------------------
+# The one failure that arrives from the network
+# --------------------------------------------------------------------------
+#
+# Everything above runs before a session exists. Length does not: the cap
+# depends on the account (1024 UTF-16 units for a caption, 2048 with Premium,
+# 4096 for a text post), so this package refuses to guess it and lets Telegram
+# answer. That makes `_too_long` the only place `MESSAGE_TOO_LONG` can be named
+# — and, until #35, the place that named nothing, so a body two characters over
+# the cap reached the model as INTERNAL: "the server's stderr has the
+# traceback", which it cannot act on.
+
+
+def schedule(client, draft, monkeypatch):
+    """Drive `schedule_post` over a fake client — the send is the only part of
+    the write surface that needs one."""
+    monkeypatch.setattr(publish, "channel_session", fake_session(client, entity=1))
+    return run(publish.schedule_post("@chan", draft, "session"))
+
+
+@pytest.mark.parametrize(
+    "error, media, cap",
+    [
+        (MessageTooLongError(None), False, "4096"),
+        (MediaCaptionTooLongError(None), True, "1024"),
+    ],
+    ids=["text-post", "photo-caption"],
+)
+def test_a_body_telegram_refuses_for_length_says_so(
+    error, media, cap, images, monkeypatch
+):
+    draft = prepare_schedule(
+        "over the cap",
+        iso_in(SOON),
+        photo_paths=[images("a.jpg")] if media else None,
+    )
+
+    with pytest.raises(SlopWriterError) as exc:
+        schedule(FakeClient(send_error=error), draft, monkeypatch)
+
+    assert exc.value.code == "MESSAGE_TOO_LONG"
+    assert cap in exc.value.message
+
+
+def test_the_length_report_counts_utf16_units_not_characters(monkeypatch):
+    """The unit is the whole point: an emoji is one character and two UTF-16
+    units, so a body reported in characters would understate itself against a
+    limit Telegram counts the other way."""
+    draft = prepare_schedule("🙂🙂", iso_in(SOON))
+
+    with pytest.raises(SlopWriterError) as exc:
+        schedule(FakeClient(send_error=MessageTooLongError(None)), draft, monkeypatch)
+
+    assert "4 UTF-16 units" in exc.value.message
+
+
+def test_nothing_was_queued_is_stated_rather_than_left_to_inference(monkeypatch):
+    """A failed send leaves the queue untouched, and the caller cannot see the
+    queue. Saying so is what stops a retry from being read as a duplicate."""
+    draft = prepare_schedule("body", iso_in(SOON))
+
+    with pytest.raises(SlopWriterError) as exc:
+        schedule(FakeClient(send_error=MessageTooLongError(None)), draft, monkeypatch)
+
+    assert "nothing was queued or changed" in exc.value.message
+
+
+def test_a_send_that_succeeds_reports_the_scheduled_post(monkeypatch):
+    """The other side of the same seam — without it the tests above would pass
+    just as well against a send that always raised."""
+    draft = prepare_schedule("body", iso_in(SOON))
+
+    result = schedule(FakeClient(), draft, monkeypatch)
+
+    assert result.action == "Scheduled"
+    assert result.item["text"] == "body"
+    assert result.item["requested"] == draft.when.isoformat()

--- a/tests/test_tg.py
+++ b/tests/test_tg.py
@@ -1,0 +1,83 @@
+"""`resolve_peer` — the one gate every Telegram path goes through, and the
+place two very different failures used to answer with the same code.
+
+A handle that names nothing and a handle this account may not see are both
+"get_entity raised"; they are not the same problem and they do not have the
+same fix. #35 split them, because an agent holding a perfectly good handle was
+being told to look for a typo. Everything else about the function is already
+exercised through the scrape and scan lifecycles — this file is only the
+classification.
+"""
+
+import pytest
+from telethon.errors import (
+    ChannelPrivateError,
+    UsernameInvalidError,
+    UsernameNotOccupiedError,
+)
+
+from slop_writer.errors import SlopWriterError
+from slop_writer.tg import resolve_peer
+
+from .conftest import run
+from .factories import CHANNEL_ID, FakeClient, channel, user
+
+CHANNEL = "@chan"
+
+
+def resolving(raised: Exception | None = None, entity=None):
+    """A client whose `@chan` is either an entity or a refusal."""
+    return FakeClient(entities={CHANNEL: raised if raised else entity})
+
+
+def test_a_peer_this_account_may_not_see_is_not_a_bad_handle():
+    """`ChannelPrivateError` is Telegram confirming the peer exists and
+    refusing it — the single most direct statement of NOT_A_MEMBER there is."""
+    with pytest.raises(SlopWriterError) as exc:
+        run(resolve_peer(resolving(ChannelPrivateError(None)), CHANNEL))
+
+    assert exc.value.code == "NOT_A_MEMBER"
+
+
+def test_the_membership_hint_does_not_send_the_caller_hunting_for_a_typo():
+    """The hint is the actionable half, and the whole point of the split: a
+    reader who goes back to check the handle wastes the turn."""
+    with pytest.raises(SlopWriterError) as exc:
+        run(resolve_peer(resolving(ChannelPrivateError(None)), CHANNEL))
+
+    assert "typo" not in (exc.value.hint or "")
+    assert "join" in (exc.value.hint or "").lower()
+
+
+@pytest.mark.parametrize(
+    "raised",
+    [
+        UsernameNotOccupiedError(None),
+        UsernameInvalidError(None),
+        ValueError("Cannot find any entity corresponding to '@chan'"),
+    ],
+    ids=["not-occupied", "invalid", "bare-value-error"],
+)
+def test_a_handle_that_names_nothing_stays_cannot_resolve(raised):
+    """The other half. These three are what a typo actually looks like coming
+    out of Telethon, and none of them says anything about membership."""
+    with pytest.raises(SlopWriterError) as exc:
+        run(resolve_peer(resolving(raised), CHANNEL))
+
+    assert exc.value.code == "CANNOT_RESOLVE"
+
+
+def test_a_resolvable_channel_is_returned_unwrapped():
+    """The split must not have made the success path conditional on anything."""
+    entity = channel(CHANNEL_ID)
+    assert run(resolve_peer(resolving(entity=entity), CHANNEL)) is entity
+
+
+def test_a_handle_that_resolves_to_a_person_is_still_refused():
+    """`NOT_A_CHANNEL` sits after the two resolve failures and is unrelated to
+    both — pinned here so a future edit to the except clauses cannot swallow
+    it."""
+    with pytest.raises(SlopWriterError) as exc:
+        run(resolve_peer(resolving(entity=user(7)), CHANNEL))
+
+    assert exc.value.code == "NOT_A_CHANNEL"


### PR DESCRIPTION
Closes #35.

`tests/test_errors.py` scans the package's source for every `code=` literal and found two members of the closed `ERROR_CODES` vocabulary that no raise site named. A code in the closed set that nothing produces is a promise to the model that never comes true.

## `MESSAGE_TOO_LONG`

`publish._too_long` already caught Telethon's `MessageTooLongError` / `MediaCaptionTooLongError` — it just carried no `code`, so the boundary's `exc.code or "INTERNAL"` sent it to the model as *"Unexpected failure — the server's stderr has the traceback."* Adding the code (plus a hint) is the whole fix. Telegram owns the cap, because it depends on the account (1024 UTF-16 units for a caption, 2048 with Premium, 4096 for a text post), which is what makes that translation the only place the code can be named.

## `NOT_A_MEMBER`

`ChannelPrivateError` is Telegram confirming the peer exists and refusing this account. It was being folded into `CANNOT_RESOLVE`, whose hint says *"check the handle for typos"* — advice that wastes a turn for a caller whose handle is fine.

It now splits out at `resolve_peer`, and the group scan classifies the three calls it makes past it:

| site | why it can refuse independently |
| --- | --- |
| `get_entity(PeerChannel(linked))` | the linked group is not the channel |
| `GetFullChannelRequest(entity)` | can refuse where `get_entity` did not |
| `iter_messages(...)` | resolving is not reading — a cached entity resolves and then refuses the history |

In the linked-group branch a bare `ValueError` counts as membership too: `linked_chat_id` came from Telegram one call earlier, so the group provably exists and an account that were in it would have seen it.

Scope was the one real fork — settled as "everywhere" rather than group-only, so the same Telethon error never answers with two codes depending on which path reached it. `CANNOT_RESOLVE` narrows to what it actually means: a handle that names nothing.

## Tests

`UNREACHED_CODES` is empty, and survives its emptiness as the ledger where a deliberately unreachable code would have to be justified.

The static scan proves a `code=` literal exists, not that the line runs — so each of the five sites gets a behavioural test too (+18: new `tests/test_tg.py`, plus `test_group_scan.py` and `test_publish.py`). `FakeClient` grows error injection: an exception stored in `entities`/`full` is raised rather than returned, plus `iter_error` and `send_error`. That also gives `schedule_post` its first coverage past `prepare_schedule`.

**335 passing on 3.11 and 3.14. Five mutants, five caught**, each by the test written for it.

## Left alone, worth a look

`scheduled.get_scheduled_message`'s hint names `tg_scrape.py scheduled` — a CLI the model calling the tool does not have. Same class of defect #18 fixed for `--at`/`--photo`, but a different ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)