### PR TITLE
fix(errors): a hint names an operation, never a surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,14 @@ disk.
     `message` / `hint` / `code`. The domain **raises**; each entrypoint decides
     how to report. Stdlib-only. `ERROR_CODES` is the closed 16-code vocabulary
     the tool contract promises, **enforced at construction** — a code outside
-    it raises `ValueError`.
+    it raises `ValueError`. Its docstring also states the rule for the *prose*
+    half: **a message or a hint names an argument or an operation, never a
+    surface** (#18, generalised by #40) — the string reaches a human at stderr
+    and a model at a tool result, and only one of them has a flag or a script.
+    Two seams cover the case where the surface really does differ, and neither
+    is a raise site: the caller supplies the noun
+    (`prepare_schedule(body_source=…)`) or the boundary swaps the whole hint
+    (`server._SETUP_HINT`).
   - `query.py` — the read-only SQL guards (`validate_read_only`) and execution
     (`run_query`, `schema_listing`). **Stdlib-only** with `db.py`, which is
     what keeps a query answerable without a Telegram client.
@@ -159,6 +166,15 @@ disk.
     so that re-adding an unreachable code is an edit somebody justifies.
     `test_tg.py` is the behavioural half for `resolve_peer`'s two codes: the
     static scan proves a `code=` literal exists, not that the line runs.
+    The same `ast` walk carries the **prose** rule since #40: every `message`
+    and `hint` *literal* is scanned for a CLI flag or a `.py` script name, over
+    the modules `server.py` can reach — a scope **computed from the import
+    graph**, module-level imports only, so `install`/`init`/`cli` fall out as a
+    consequence (their reader is always a human) and a new domain module joins
+    the scan on its own. Interpolated values are skipped on purpose: the dev
+    CLI passing `--file draft.md` through `body_source` is that seam working.
+    It replaced a `test_publish.py` check scoped to one file, which is how the
+    defect survived next door in `scheduled.py`.
   - Nothing in the suite touches a Telegram session, `.tg-analytic/`, or the
     network. Live runs stay the acceptance step; they are no longer the only
     one.

--- a/src/slop_writer/errors.py
+++ b/src/slop_writer/errors.py
@@ -9,6 +9,21 @@ server will build its error payload.
 
 Stdlib-only, like `db`: importing this must not drag Telethon in.
 
+**A message or a hint names an argument or an operation, never a surface.**
+The same string reaches a human reading stderr and a model reading a tool
+result, and only one of them has `--at` or a script to run; the server passes
+every non-setup hint through verbatim (`test_server.py`), so a remedy phrased
+for the wrong reader is a remedy that reader cannot follow. Where the surface
+genuinely differs the package has two seams and neither is a raise site: the
+caller supplies the differing noun (`publish.prepare_schedule(body_source=…)`
+— the CLI says `--file`, the server says the `body` argument), or the boundary
+swaps the whole hint (`server._SETUP_HINT`, for `NO_CREDENTIALS`/`NO_SESSION`,
+where the remedy really is a different command per caller). Everything else
+stays caller-neutral, and `test_errors.py` scans the source for the two forms
+that are unambiguously a CLI. The rule used to live in `publish.py`'s
+docstring, scoped to the one file #18 found the defect in; #40 found it had
+already been broken next door in `scheduled.py`.
+
 `code` is the machine-readable half, from the closed vocabulary decided in
 Lancetnik/slop-writer#15 (`ERROR_CODES`) and completed in #17, which found the
 original eleven short by six failures. It stays optional in the signature —

--- a/src/slop_writer/publish.py
+++ b/src/slop_writer/publish.py
@@ -16,12 +16,12 @@ takes everything the caller supplied and fails before a session is required,
 which keeps a bad `at` or a missing photo cheap to report and stops the two
 callers (CLI, server) from having to reproduce the same order of checks.
 
-Messages here name **arguments, never CLI flags**. The same string reaches a
-human reading stderr and a model reading a tool result, and `--at` is a thing
-only one of them has — a model told to fix `--at` is being pointed at a
-surface it cannot see. Where the origin genuinely differs the caller supplies
-it (`body_source`): the CLI says "stdin", the server says "the `body`
-argument".
+Messages here name **arguments, never CLI flags** — the package-wide rule, now
+stated in `errors.py`. This module is where it was found broken (#18) and it
+owns the one seam for the case the rule cannot cover: the body's origin
+genuinely differs per caller, so the caller supplies it (`body_source`) rather
+than the raise site guessing. The CLI says "stdin" or `--file draft.md`, the
+server says "the `body` argument", and both are right for their reader.
 """
 
 import logging

--- a/src/slop_writer/scheduled.py
+++ b/src/slop_writer/scheduled.py
@@ -84,7 +84,11 @@ async def get_scheduled_message(client, entity, msg_id: int) -> Message:
 
     One round-trip via GetScheduledMessages (no full-history scan). Fails with
     an actionable message if nothing matches — the id is most likely stale
-    (the post published, or was already removed)."""
+    (the post published, or was already removed).
+
+    The hint names the *operation*, not the surface that performs it: listing
+    the queue is a tool for one caller and a command for the other, and this
+    function knows which one it is serving no more than `errors.py` does."""
     result = await client(GetScheduledMessagesRequest(peer=entity, id=[msg_id]))
     found = [
         m
@@ -94,7 +98,9 @@ async def get_scheduled_message(client, entity, msg_id: int) -> Message:
     if not found:
         raise SlopWriterError(
             f"No scheduled post #{msg_id} in the queue.",
-            hint="List the queue with `tg_scrape.py scheduled --channel <chan>`.",
+            hint="List the channel's scheduled queue again and use a current "
+            "id — these are sched-msg ids, and they go stale the moment a post "
+            "publishes or is removed.",
             code="NO_SUCH_MESSAGE",
         )
     return found[0]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -12,9 +12,17 @@ So this module checks the vocabulary two ways: at construction, where
 `SlopWriterError.__init__` enforces it, and statically over the package's own
 source, where every `code=` literal is visible whether or not a test can reach
 the line it sits on.
+
+The same argument, and the same `ast` walk, carries the other half of the
+promise — the *prose*. `message` and `hint` are read by whichever caller the
+domain is serving, and #40 found a hint telling a model to run a script only
+the CLI has. That defect is invisible to a construction-time check for exactly
+the reason above, so it gets the static treatment too.
 """
 
 import ast
+import re
+from collections import deque
 from pathlib import Path
 
 import pytest
@@ -155,3 +163,127 @@ def test_the_tool_boundary_names_flood_wait_once_for_every_tool():
     named = _codes_named_in_source()["FLOOD_WAIT"]
     assert "server.py" in named
     assert named <= {"server.py", "init.py"}
+
+
+# --------------------------------------------------------------------------
+# The prose half: a remedy the reader can actually follow
+# --------------------------------------------------------------------------
+#
+# `errors.py` states the rule — a message or a hint names an argument or an
+# operation, never a surface. It is enforced here rather than at the raise
+# sites because it is a property of a *literal*, and literals are visible in
+# source whether or not any test reaches the line.
+#
+# The scan is deliberately narrow: it catches the two forms that are
+# unambiguously a command line, not the general claim. A hint that says
+# "run `slop-writer init`" passes and should — that command is real, a human
+# runs it, and `server._SETUP_HINT` swaps in the server's own wording anyway.
+# What no reader of a tool result has is a flag or a script file.
+_CLI_ONLY = re.compile(r"--[a-z]|[\w-]+\.py\b")
+
+
+def _all_modules() -> dict[str, Path]:
+    return {p.stem: p for p in Path(slop_writer.__file__).parent.glob("*.py")}
+
+
+def _server_reachable() -> dict[str, Path]:
+    """The modules a tool call can raise from, by walking `server.py`'s imports.
+
+    Derived rather than listed, so the scope maintains itself: a module the
+    server starts importing joins the scan without anyone remembering, and the
+    exclusions are a consequence rather than a policy. `install`, `init` and
+    `cli` fall out because nothing on a tool path imports them — their reader
+    is always a human at a terminal, which is why "run `slop-writer install`
+    again" is exactly the right thing for them to say.
+
+    **Module-level imports only.** `render.summarize_install` imports `install`
+    from inside its own body, and that deferred import is the author drawing
+    this very line: the function renders for a human at a terminal, and the
+    module says so. Following it would drag the whole CLI half back in."""
+    modules = _all_modules()
+    seen: set[str] = set()
+    queue = deque(["server"])
+    while queue:
+        name = queue.popleft()
+        if name in seen or name not in modules:
+            continue
+        seen.add(name)
+        tree = ast.parse(modules[name].read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, ast.ImportFrom) and node.level and node.module:
+                queue.append(node.module.split(".")[0])
+    return {name: modules[name] for name in seen}
+
+
+def _failure_prose() -> list[tuple[str, int, str]]:
+    """Every `message`/`hint` string a failure carries, as written in source.
+
+    Only the *literal* parts of an f-string: an interpolated value is the
+    caller's (`body_source`), and the CLI passing `--file draft.md` through it
+    is the seam working, not a violation of it."""
+
+    def literals(node: ast.expr) -> list[str]:
+        if isinstance(node, ast.Constant):
+            return [node.value] if isinstance(node.value, str) else []
+        if isinstance(node, ast.JoinedStr):
+            return [
+                v.value for v in node.values
+                if isinstance(v, ast.Constant) and isinstance(v.value, str)
+            ]
+        if isinstance(node, ast.BinOp):
+            return literals(node.left) + literals(node.right)
+        return []
+
+    found: list[tuple[str, int, str]] = []
+    for name, path in sorted(_server_reachable().items()):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if not isinstance(node, ast.Call):
+                continue
+            called = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+            if called not in {"SlopWriterError", "UsageError"}:
+                continue
+            parts = list(node.args[:1]) + [
+                kw.value for kw in node.keywords if kw.arg == "hint"
+            ]
+            for part in parts:
+                found.extend(
+                    (f"{name}.py", node.lineno, text) for text in literals(part)
+                )
+    return found
+
+
+def test_the_scan_reaches_the_modules_a_tool_call_runs_through():
+    """The guard above is only as good as its scope, and the scope is computed.
+    A `server.py` rename or an import deleted by accident would otherwise
+    shrink it to nothing and leave every test below passing vacuously."""
+    reached = set(_server_reachable())
+    assert {"server", "publish", "scheduled", "tg", "query", "group"} <= reached
+    # Not reachable, and the reason the scan can afford to be strict.
+    assert reached.isdisjoint({"install", "init", "cli"})
+
+
+def test_no_failure_points_the_reader_at_a_surface_it_may_not_have():
+    """A flag or a script name in a message or a hint is a remedy addressed to
+    exactly one of two readers. #18 found `--at` and `--photo` being handed to
+    a model; #40 found `tg_scrape.py scheduled --channel <chan>` still doing it
+    from the read module next door, which #18's file-scoped test never opened.
+
+    Every non-setup hint crosses to the model verbatim
+    (`test_server.py::test_a_domain_hint_survives_when_it_is_not_a_setup_failure`),
+    so there is no later stage that could rewrite this one."""
+    offenders = [
+        (module, line, text)
+        for module, line, text in _failure_prose()
+        if _CLI_ONLY.search(text)
+    ]
+    assert not offenders
+
+
+def test_the_scan_would_catch_the_defect_it_was_written_for():
+    """The scan is worth only what it rejects, and everything it guards now
+    passes — so the regex is checked against the string #40 actually found,
+    and against the two shapes that must keep passing."""
+    assert _CLI_ONLY.search("List the queue with `tg_scrape.py scheduled --channel x`")
+    assert _CLI_ONLY.search("Shorten the body, or drop --photo and retry.")
+    assert not _CLI_ONLY.search("Ask the user to run `slop-writer init`, then stop.")
+    assert not _CLI_ONLY.search("Scrape the channel first — em dashes are — fine.")

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -248,26 +248,14 @@ def test_caption_above_without_photos_is_rejected():
     assert "at least one photo" in exc.value.message
 
 
-@pytest.mark.parametrize(
-    "call",
-    [
-        lambda: parse_schedule_time("tomorrow"),
-        lambda: parse_schedule_time(iso_in(TOO_SOON)),
-        lambda: parse_schedule_time(
-            (datetime.now(UTC) + SOON).replace(tzinfo=None).isoformat()
-        ),
-        lambda: check_photos(["/nope/missing.jpg"]),
-        lambda: check_photos(["/nope/clip.gif"]),
-        lambda: prepare_schedule("body", iso_in(SOON), caption_above=True),
-    ],
-)
-def test_no_message_names_a_cli_flag(call):
-    """The same string reaches a human reading stderr and a model reading a
-    tool result, and `--at` is a thing only one of them has. Found live: the
-    MCP server was telling the model to fix a flag it cannot see."""
-    with pytest.raises(SlopWriterError) as exc:
-        call()
-    assert "--" not in exc.value.message
+# `test_no_message_names_a_cli_flag` lived here and is gone: it asserted
+# `"--" not in message` over six hand-listed calls, which is why the same
+# defect survived in `scheduled.py`, a module this file has no reason to call.
+# `test_errors.py::test_no_failure_points_the_reader_at_a_surface_it_may_not_have`
+# is the same rule over every raise site the server can reach, and it reaches
+# hints as well as messages. The runtime half — that `body_source` reaches the
+# message the model reads — is `test_server.py`'s, at the boundary that
+# supplies it.
 
 
 def test_caption_above_needs_something_to_place_above(images):


### PR DESCRIPTION
Resolves [A read-path hint still names a CLI the model cannot run](https://github.com/Lancetnik/slop-writer/issues/40).

`get_scheduled_message`'s `NO_SUCH_MESSAGE` hint said *"List the queue with `tg_scrape.py scheduled --channel <chan>`"*. The model reading that tool result has no `tg_scrape.py` — it has `list_scheduled`. Same defect [#18](https://github.com/Lancetnik/slop-writer/issues/18) fixed in `publish.py`, surviving in the read module next door.

## The sweep

Every `message`/`hint` literal in `src/slop_writer/`, and this is the only instance. Not counter-examples:

- `init.py` / `install.py` name `slop-writer install` at a reader who is always a human at a terminal.
- `tg.py`'s two setup hints are rewritten wholesale by `server._SETUP_HINT` before they reach a model.
- Renderers and tool descriptions are clean.

## Where the rule lives

`errors.py` — the module that defines `message` and `hint`: **a message or a hint names an argument or an operation, never a surface.** With the two seams for a surface that genuinely differs per caller, neither of which is a raise site: the caller supplies the noun (`prepare_schedule(body_source=…)`), or the boundary swaps the hint (`server._SETUP_HINT`). `publish.py` keeps only the half it owns.

## What enforces it

`test_errors.py`, which already owns the `ast` walk and the argument for it — a raise site needing a Telegram session is invisible to a runtime check, and `test_a_domain_hint_survives_when_it_is_not_a_setup_failure` proves every non-setup hint crosses to the model verbatim, so no later stage could rewrite one.

- Scans **literals** for the two forms that are unambiguously a command line: a flag and a `.py`. Deliberately narrow — `` run `slop-writer init` `` passes and should.
- Scope is **computed from `server.py`'s import graph**, not listed, so it fails closed on additions: a new server-reached module is scanned without anyone remembering, and `install`/`init`/`cli` drop out as a consequence rather than a policy.
- **Module-level imports only** — `render.summarize_install` imports `install` from inside its own body, and that deferred import is the author drawing this same line.
- Interpolated values skipped: the dev CLI passing `--file draft.md` through `body_source` is that seam working, not a violation.

`test_publish.py::test_no_message_names_a_cli_flag` is deleted — six hand-listed calls in one file is exactly why the defect survived — with a comment where it was pointing at the replacement.

## Verification

337 passed. Six mutants, five caught:

| Mutant | Result |
| --- | --- |
| The #40 hint restored verbatim | caught |
| A flag added to a `group.py` message | caught |
| A `.py` added to a `query.py` hint | caught |
| `server.py` renamed — scope silently empties | caught |
| A new server-reached module with a bad hint | caught |
| A flag added to an `install.py` hint | **passes** — the scope doing its job |

`check_schema_doc.py` OK; nothing under `skills/` names a script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)