### PR TITLE
feat(errors): an unresolvable handle answers with the channels there are

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,14 @@ Non-obvious, and enforced in `server.py`:
   place a Telethon flood-wait can be caught once, and turns anything else into
   `INTERNAL` rather than a traceback. The SDK prefixes the text with
   `Error executing tool <name>: `; the JSON is the tail.
+- **Two hints belong to the entrypoint, not to the raise site**, which is why
+  `_guarded` is a factory taking the project's `output_dir`: the setup pair
+  answers with `slop-writer init` (`_SETUP_HINT`), and `CANNOT_RESOLVE`
+  answers with `db.scraped_channels()` — the channels this project holds
+  (#43). Both are facts about where the server runs, and the second replaces
+  the domain's "check the handle for typos", which is the wrong remedy for an
+  agent that never had a handle. A hosted server swaps `_resolve_hint` for a
+  tenant lookup and `tg.py` does not move.
 - **Argument validation failures are the one gap**: pydantic rejects a bad
   `select` arm *before* `_guarded` runs, so those come back as a pydantic
   message rather than the JSON contract.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,9 +6,23 @@ the channel (the one write capability; everything else only reads).
 
 ## Language
 
+**Project**:
+The directory the server runs in — one `.tg-analytic/`, and the unit of
+state. Holds any number of scraped channels, one of which is primary.
+
 **Channel**:
 The Telegram broadcast channel being analyzed (e.g. @fastnewsdev). Posts
 originate here; only admins can post.
+
+**Scraped channel**:
+A channel this project holds a local database for, i.e. one scanned at least
+once. The set of them is what the project can answer for without reaching
+Telegram.
+
+**Primary channel**:
+The scraped channel an agent falls back to when the user names none.
+Remembered by the client across sessions, never stored in the project.
+_Avoid_: default channel, main channel
 
 **Discussion group**:
 The supergroup linked to the channel (`linked_chat_id`), where channel posts

--- a/skills/slop-writer/SKILL.md
+++ b/skills/slop-writer/SKILL.md
@@ -87,6 +87,13 @@ A tool that fails with a setup error tells you what the user must run. It is
 an interactive login on a terminal — Telegram prompts for an SMS code — so you
 cannot complete it from a tool call. Relay the instruction, stop, and wait.
 
+## When no channel is named
+
+Ask the user which channel they mean, and record the answer wherever your
+client keeps notes across sessions, so it is asked once rather than every
+session. `CANNOT_RESOLVE` names the channels this project has data for —
+retry with one of those.
+
 ## The write gate
 
 `publish_*` reaches a live channel. Run one only on an explicit instruction

--- a/src/slop_writer/db.py
+++ b/src/slop_writer/db.py
@@ -200,6 +200,21 @@ def db_path_for(output_dir: Path, channel: str) -> Path:
     return output_dir / f"{safe}.db"
 
 
+def scraped_channels(output_dir: Path) -> list[str]:
+    """The channels this project holds data for, one per DB file.
+
+    The inverse of `db_path_for`, and beside it so the
+    `.tg-analytic/<channel>.db` layout stays the knowledge of one module.
+    Touches no database and needs no session: a project can say which
+    channels it knows before Telegram is reachable at all, which is what
+    lets a resolve failure answer with them (#43).
+
+    Sorted, so the string a caller builds out of this is stable run to run."""
+    if not output_dir.is_dir():
+        return []
+    return sorted(path.stem for path in output_dir.glob("*.db"))
+
+
 def _drop_legacy_tables(conn: sqlite3.Connection) -> None:
     """Self-heal DB files created before the post_comments merge.
 

--- a/src/slop_writer/errors.py
+++ b/src/slop_writer/errors.py
@@ -12,13 +12,16 @@ Stdlib-only, like `db`: importing this must not drag Telethon in.
 **A message or a hint names an argument or an operation, never a surface.**
 The same string reaches a human reading stderr and a model reading a tool
 result, and only one of them has `--at` or a script to run; the server passes
-every non-setup hint through verbatim (`test_server.py`), so a remedy phrased
-for the wrong reader is a remedy that reader cannot follow. Where the surface
-genuinely differs the package has two seams and neither is a raise site: the
-caller supplies the differing noun (`publish.prepare_schedule(body_source=…)`
-— the CLI says `--file`, the server says the `body` argument), or the boundary
-swaps the whole hint (`server._SETUP_HINT`, for `NO_CREDENTIALS`/`NO_SESSION`,
-where the remedy really is a different command per caller). Everything else
+through verbatim every hint it does not own (`test_server.py`), so a remedy
+phrased for the wrong reader is a remedy that reader cannot follow. Where the
+remedy is genuinely the caller's the package has two seams and neither is a
+raise site: the caller supplies the differing noun
+(`publish.prepare_schedule(body_source=…)` — the CLI says `--file`, the server
+says the `body` argument), or the boundary swaps the whole hint
+(`server._SETUP_HINT` for `NO_CREDENTIALS`/`NO_SESSION`, where the command
+differs per caller; `server._resolve_hint` for `CANNOT_RESOLVE`, where the
+remedy is the list of channels the *project* holds and no raise site under
+`slop_writer` may know where they live). Everything else
 stays caller-neutral, and `test_errors.py` scans the source for the two forms
 that are unambiguously a CLI. The rule used to live in `publish.py`'s
 docstring, scoped to the one file #18 found the defect in; #40 found it had

--- a/src/slop_writer/server.py
+++ b/src/slop_writer/server.py
@@ -49,7 +49,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from telethon.errors import FloodWaitError
 
 from . import __version__
-from .db import data_dir
+from .db import data_dir, scraped_channels
 from .errors import SlopWriterError
 from .group import scan_group
 from .publish import edit_post, parse_schedule_time, prepare_schedule, render_body
@@ -115,6 +115,31 @@ _SETUP_HINT = (
     "Telegram's login prompts for an SMS code on a TTY, so it cannot be "
     "completed from a tool call."
 )
+
+
+def _resolve_hint(output_dir: Path) -> str:
+    """A handle that names nothing is answered with the ones that do.
+
+    Which channels exist is a fact about the *caller*, not about the Telegram
+    lookup that failed, so it is attached here rather than in `resolve_peer` —
+    the same split as `_SETUP_HINT`, and the seam a hosted server replaces
+    with a tenant lookup while `tg.py` stays untouched.
+
+    It replaces the domain's "check the handle for typos", which is the wrong
+    remedy for the agent that had no handle to begin with: #41 watched five of
+    thirteen sessions answer that question by reading `.tg-analytic/`, one of
+    them out of a neighbouring checkout."""
+    channels = scraped_channels(output_dir)
+    if not channels:
+        return (
+            "Ask the user which channel they mean, then scrape it — this "
+            "project has no channel data yet."
+        )
+    return (
+        "Retry with one of the channels this project has data for: "
+        f"{', '.join(channels)}. A private group also resolves only for an "
+        "account that has already seen it."
+    )
 
 
 def normalize_channel(handle: str) -> str:
@@ -199,7 +224,9 @@ def _payload(code: str, message: str, hint: str | None, **extra) -> str:
     )
 
 
-def _guarded(fn: Callable[..., Awaitable[str]]) -> Callable[..., Awaitable[str]]:
+def _guarded(
+    output_dir: Path,
+) -> Callable[[Callable[..., Awaitable[str]]], Callable[..., Awaitable[str]]]:
     """Turn every failure into the `{code, message, hint}` contract.
 
     Raising (rather than returning) is what sets `isError: true`; the SDK
@@ -207,42 +234,62 @@ def _guarded(fn: Callable[..., Awaitable[str]]) -> Callable[..., Awaitable[str]]
     the tail of the string rather than the whole of it. That prefix is the one
     concession — the JSON itself crosses verbatim.
 
+    Takes `output_dir` because two of the codes are answered by the
+    *entrypoint* rather than by the domain that raised them: the setup pair
+    with `slop-writer init`, and `CANNOT_RESOLVE` with the channels this
+    project holds. Both are facts about where the server runs, which no raise
+    site under `slop_writer` is allowed to know.
+
     `functools.wraps` matters beyond tidiness: FastMCP derives the tool's
     input schema from `inspect.signature`, which follows `__wrapped__`."""
 
-    @functools.wraps(fn)
-    async def wrapper(*args, **kwargs) -> str:
-        try:
-            return await fn(*args, **kwargs)
-        except SlopWriterError as exc:
-            hint = _SETUP_HINT if exc.code in _SETUP_CODES else exc.hint
-            raise ToolError(
-                _payload(exc.code or "INTERNAL", exc.message, hint)
-            ) from None
-        except FloodWaitError as exc:
-            # Telethon raises this from any call, at any depth, so the boundary
-            # is the only place that can name it once.
-            raise ToolError(
-                _payload(
-                    "FLOOD_WAIT",
-                    f"Telegram rate-limited this account for {exc.seconds}s.",
-                    "Wait it out and retry; narrow the selection to ask for less.",
-                    seconds=exc.seconds,
+    def decorator(
+        fn: Callable[..., Awaitable[str]],
+    ) -> Callable[..., Awaitable[str]]:
+        @functools.wraps(fn)
+        async def wrapper(*args, **kwargs) -> str:
+            try:
+                return await fn(*args, **kwargs)
+            except SlopWriterError as exc:
+                if exc.code in _SETUP_CODES:
+                    hint = _SETUP_HINT
+                elif exc.code == "CANNOT_RESOLVE":
+                    hint = _resolve_hint(output_dir)
+                else:
+                    hint = exc.hint
+                raise ToolError(
+                    _payload(exc.code or "INTERNAL", exc.message, hint)
+                ) from None
+            except FloodWaitError as exc:
+                # Telethon raises this from any call, at any depth, so the
+                # boundary is the only place that can name it once.
+                raise ToolError(
+                    _payload(
+                        "FLOOD_WAIT",
+                        f"Telegram rate-limited this account for {exc.seconds}s.",
+                        "Wait it out and retry; narrow the selection to ask "
+                        "for less.",
+                        seconds=exc.seconds,
+                    )
+                ) from None
+            except Exception as exc:
+                # Traceback to stderr for the human; a contract-shaped payload
+                # for the model, which can do nothing with a traceback anyway.
+                log.exception(
+                    "unhandled error in %s", getattr(fn, "__name__", "tool")
                 )
-            ) from None
-        except Exception as exc:
-            # Traceback to stderr for the human; a contract-shaped payload for
-            # the model, which can do nothing with a traceback anyway.
-            log.exception("unhandled error in %s", getattr(fn, "__name__", "tool"))
-            raise ToolError(
-                _payload(
-                    "INTERNAL",
-                    f"{type(exc).__name__}: {exc}",
-                    "Unexpected failure — the server's stderr has the traceback.",
-                )
-            ) from None
+                raise ToolError(
+                    _payload(
+                        "INTERNAL",
+                        f"{type(exc).__name__}: {exc}",
+                        "Unexpected failure — the server's stderr has the "
+                        "traceback.",
+                    )
+                ) from None
 
-    return wrapper
+        return wrapper
+
+    return decorator
 
 
 async def assert_text_only(mcp: FastMCP) -> None:
@@ -287,7 +334,8 @@ def build_server(project_root: Path) -> FastMCP:
         """The only registration path. Pins the two things a per-tool decision
         would eventually get wrong: text-only output, and the error contract."""
         def decorator(fn):
-            return mcp.tool(structured_output=False, **kwargs)(_guarded(fn))
+            guarded = _guarded(output_dir)(fn)
+            return mcp.tool(structured_output=False, **kwargs)(guarded)
         return decorator
 
     def _session() -> None:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -10,7 +10,14 @@ import sqlite3
 
 import pytest
 
-from slop_writer.db import SCHEMA, data_dir, db_path_for, env_path, open_db
+from slop_writer.db import (
+    SCHEMA,
+    data_dir,
+    db_path_for,
+    env_path,
+    open_db,
+    scraped_channels,
+)
 
 
 def test_paths_hang_off_the_project_root_the_caller_names(tmp_path):
@@ -29,6 +36,26 @@ def test_paths_hang_off_the_project_root_the_caller_names(tmp_path):
 )
 def test_one_db_file_per_channel(tmp_path, channel, filename):
     assert db_path_for(tmp_path, channel).name == filename
+
+
+def test_the_scraped_channels_are_the_db_files_and_nothing_else(tmp_path):
+    """The answer a resolve failure carries (#43), so it reads the directory
+    the same way `db_path_for` writes it — and ignores the session, the .env
+    and the media directory sitting beside them."""
+    output_dir = data_dir(tmp_path)
+    open_db(output_dir, "@fastnewsdev")
+    open_db(output_dir, "@chatter")
+    (output_dir / "session.session").touch()
+    (output_dir / ".env").touch()
+    (output_dir / "media").mkdir()
+
+    assert scraped_channels(output_dir) == ["chatter", "fastnewsdev"]
+
+
+def test_a_project_before_its_first_scrape_holds_no_channels(tmp_path):
+    """`.tg-analytic/` does not exist until something opens a DB, and a
+    missing directory is a project with no data, not a failure."""
+    assert scraped_channels(data_dir(tmp_path)) == []
 
 
 def test_open_creates_the_directory_and_every_table(tmp_path):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,6 +28,7 @@ import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 from telethon.errors import FloodWaitError
 
+from slop_writer.db import data_dir
 from slop_writer.errors import ERROR_CODES, SlopWriterError
 from slop_writer.server import (
     SERVER_NAME,
@@ -334,12 +335,12 @@ def test_a_rejected_query_is_not_an_internal_error(server):
     assert payload["code"] in {"QUERY_REJECTED", "NO_DATA"}
 
 
-def test_a_flood_wait_carries_its_seconds(server):
+def test_a_flood_wait_carries_its_seconds(tmp_path):
     """Telethon raises this from any call at any depth, so the boundary is the
     only place it can be named once — and the number is what the model needs
     to decide between waiting and narrowing the request."""
 
-    @_guarded
+    @_guarded(data_dir(tmp_path))
     async def flooded():
         raise FloodWaitError(request=None)
 
@@ -350,11 +351,11 @@ def test_a_flood_wait_carries_its_seconds(server):
     assert "seconds" in payload
 
 
-def test_an_unexpected_exception_answers_in_the_contract(server):
+def test_an_unexpected_exception_answers_in_the_contract(tmp_path):
     """Even a bug answers as JSON: a traceback is something the model can do
     nothing with, and `isError` without a code breaks the branch."""
 
-    @_guarded
+    @_guarded(data_dir(tmp_path))
     async def broken():
         raise ZeroDivisionError("boom")
 
@@ -365,17 +366,60 @@ def test_an_unexpected_exception_answers_in_the_contract(server):
     assert "ZeroDivisionError" in payload["message"]
 
 
-def test_a_domain_hint_survives_when_it_is_not_a_setup_failure(server):
-    """Only `NO_CREDENTIALS`/`NO_SESSION` get the server's remedy swapped in;
-    every other hint is the domain's own and must cross untouched."""
+def test_a_domain_hint_survives_when_it_is_not_a_setup_failure(tmp_path):
+    """Only the setup pair and `CANNOT_RESOLVE` get the server's remedy
+    swapped in; every other hint is the domain's own and must cross
+    untouched."""
 
-    @_guarded
+    @_guarded(data_dir(tmp_path))
     async def refused():
         raise SlopWriterError("nope", hint="try the other thing", code="NOT_ADMIN")
 
     with pytest.raises(ToolError) as exc:
         run(refused())
     assert payload_of(exc.value)["hint"] == "try the other thing"
+
+
+def unresolvable(output_dir) -> dict:
+    """Drive `CANNOT_RESOLVE` through the boundary and read its hint.
+
+    Raised directly rather than through a tool: reaching `resolve_peer` needs
+    a session, and the hint is the entrypoint's work either way."""
+
+    @_guarded(output_dir)
+    async def missing():
+        raise SlopWriterError(
+            "Cannot resolve @typo",
+            hint="Check the handle for typos.",
+            code="CANNOT_RESOLVE",
+        )
+
+    with pytest.raises(ToolError) as exc:
+        run(missing())
+    return payload_of(exc.value)
+
+
+def test_an_unresolvable_handle_names_the_channels_the_project_has(tmp_path):
+    """#43: the agent that cannot name a channel reads `.tg-analytic/` to find
+    one — five of thirteen sessions in #41's drive did, one of them out of a
+    neighbouring checkout. The failure it should have hit answers instead."""
+    output_dir = data_dir(tmp_path)
+    output_dir.mkdir(parents=True)
+    (output_dir / "fastnewsdev.db").touch()
+    (output_dir / "opensource_findings_chat.db").touch()
+
+    hint = unresolvable(output_dir)["hint"]
+    assert "fastnewsdev" in hint
+    assert "opensource_findings_chat" in hint
+
+
+def test_a_project_with_no_data_is_told_to_scrape_rather_than_offered_nothing(
+    tmp_path,
+):
+    """The list is empty on every project before its first scrape, and
+    "retry with one of these" over nothing is an instruction to guess."""
+    hint = unresolvable(data_dir(tmp_path))["hint"]
+    assert "scrape" in hint
 
 
 def test_the_payload_is_json_in_the_text_block_not_structured_content(server):


### PR DESCRIPTION
Resolves [The agent has no way to learn which channels a project holds](https://github.com/Lancetnik/slop-writer/issues/43).

Five of thirteen sessions in [#41](https://github.com/Lancetnik/slop-writer/issues/41)'s drive opened with `ls -la .tg-analytic/` — one of them through a symlink into a neighbouring checkout, reading its DBs with `sqlite3`. Every answer was right, which is what makes it worth fixing: the workaround is invisible, it reaches past the tool surface into a directory the server owns, and on a machine where that directory is elsewhere or unreadable it degrades to a guess with no error.

## No twelfth tool

The ticket's fork was a router line *or* a `list_channels` tool. Neither half whole: a "don't read the directory" line answers *don't* without answering *then how*, and a tool answers a question the failing agents never asked out loud — they made no call at all.

**`CANNOT_RESOLVE` carries the list.** It already fires exactly where the question is live, and the drive proved the model reads and follows it (`fastnews` recovered to a real handle twice). Its hint stops saying *"check the handle for typos"* — the wrong remedy for an agent holding a perfectly good handle, and the same defect [#35](https://github.com/Lancetnik/slop-writer/issues/35) fixed one level up:

> Retry with one of the channels this project has data for: fastnewsdev, opensource_findings_chat. A private group also resolves only for an account that has already seen it.

A project before its first scrape gets the other branch — *ask the user which channel they mean, then scrape it* — because "retry with one of these" over an empty list is an instruction to guess.

## The agent that never had a handle

The error fires only after a wrong handle; the five sessions had none to be wrong with. That case is the skill's, stated **positively** — naming `ls .tg-analytic/` to forbid it drags the reflex into context, and the drive proved it is already the default:

> **When no channel is named** — Ask the user which channel they mean, and record the answer wherever your client keeps notes across sessions, so it is asked once rather than every session. `CANNOT_RESOLVE` names the channels this project has data for — retry with one of those.

*Record the answer* is what turns "ask the user" from a tax paid every session into one question. **Project state storing a primary channel was rejected, not deferred**: a silently substituted channel is the same quiet wrong answer the four invariants exist to prevent, except the wrong party is the config, and `run_query` then reports plausible numbers about the wrong channel. Memory belongs with the client, where the mistake and its fix are the same party's.

## Where the list is attached

At the **entrypoint**, beside `_SETUP_HINT` — which channels exist is a fact about where the server runs, not about the Telegram lookup that failed. So `_guarded` becomes a factory over `output_dir` and `tg.resolve_peer` is untouched; a hosted server swaps `_resolve_hint` for a tenant lookup and `tg.py` does not move. Cost stated: the dev CLIs get no list, and their reader is a human already looking at the directory.

`db.scraped_channels` is the inverse of `db_path_for` and lives beside it, so one module knows the `.tg-analytic/<channel>.db` layout. It opens no database and needs no session — a project can name its channels before Telegram is reachable at all.

`errors.py`'s prose rule is amended: *"the server passes every **non-setup** hint through verbatim"* stopped being true the moment a second code got an entrypoint-owned hint.

## Verification

341 green (+4). Three mutants, three caught: the `CANNOT_RESOLVE` branch removed, the empty-project branch never firing, the list never populated. `check_schema_doc.py` OK.

`CONTEXT.md` gains **Project**, **Scraped channel** and **Primary channel** — the last of which also settles the map's fog patch *"whether a project can hold more than one channel, and how a tool call selects among them"*: many scraped, one primary, selection by the user or the client's memory and never by project state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
