### PR TITLE
test(packaging): pin the skill's version to the package's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ node_modules/
 .agents
 .claude/skills/
 skills-lock.json
+# Agent worktrees: real checkouts of this repo, which `git add -A` would
+# otherwise stage as gitlinks pointing at commits no clone can resolve.
+.claude/worktrees/
 
 .codegraph
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,10 +325,19 @@ Non-obvious, and enforced in `server.py`:
 All three components, always the `v` prefix, no suffix, no two-component form
 (`v2.1` is **not** a release tag), no bare `2.0.0`.
 
-- The tag must equal `v` + the `version` in `pyproject.toml`, which stays the
-  single place a version is declared (`slop_writer.__version__` reads it back
-  from the installed distribution metadata). One version covers package **and**
-  skill — #21 accepted the drift that buys.
+- The tag must equal `v` + the `version` in `pyproject.toml`, which is the
+  **source** of the version (`slop_writer.__version__` reads it back from the
+  installed distribution metadata). One version covers package **and** skill —
+  #21 accepted the drift that buys.
+- **A bump is a two-file edit**: `pyproject.toml` and `SKILL.md`'s
+  `metadata.version`, byte-identical, three components. The skill needs its own
+  copy because the `npx skills add` channel serves the repository directory and
+  never sees `pyproject.toml`, and nothing derives it — the file is static in
+  both channels. `tests/test_packaging.py` pins the copy to the source, which
+  is the only thing standing between a patch release and a skill that
+  misreports which release is on disk. Through 0.4.0 they were aligned by hand
+  exactly once (#30, resetting the skill's own `2.1` counter onto the package's
+  line), and 0.4.0 shipped saying `0.4` — hence the guard.
 - `publish.yaml` gates a release on tag-vs-`pyproject` agreement, but it strips
   the `v` with `${GITHUB_REF_NAME#v}`, so it accepts a bare `2.0.0` and would
   accept `v2.1` if `pyproject` said `2.1`. **The naming rule is a convention

--- a/skills/slop-writer/SKILL.md
+++ b/skills/slop-writer/SKILL.md
@@ -7,7 +7,7 @@ compatibility: >-
 license: Apache-2.0
 metadata:
   author: Lancetnik
-  version: "0.4"
+  version: "0.4.0"
 ---
 
 # Telegram channel analytics

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -6,6 +6,7 @@ the same failure mode, and it is invisible — every test would still pass, just
 against last release's code.
 """
 
+import re
 import subprocess
 import sys
 import textwrap
@@ -59,6 +60,40 @@ def test_the_skill_is_declared_as_wheel_data():
     pyproject = tomllib.loads((REPO / "pyproject.toml").read_text())
     assert pyproject["tool"]["uv"]["build-backend"]["data"]["purelib"] == "skills"
     assert (REPO / "skills" / "slop-writer" / "SKILL.md").is_file()
+
+
+def test_the_skill_version_is_the_package_version():
+    """One version covers package and skill (#21), so `pyproject.toml` is the
+    source and `SKILL.md`'s frontmatter is a copy — the only one, and the only
+    reason this check exists.
+
+    A copy is what the two install channels force. `slop-writer install` takes
+    the skill out of the wheel, `npx skills add` takes it out of the
+    repository, and the second never sees `pyproject.toml`, so the version has
+    to be written where the skill is. Nothing derives it: the file is static in
+    both channels.
+
+    Drift here is silent in a way the packaging above is not. A missing wheel
+    declaration breaks a user's first `install`; a stale skill version breaks
+    nothing and just misreports which release is on disk — through 0.4.0 the
+    field had been aligned by hand exactly once, when #30 reset the skill's own
+    `2.1` counter onto the package's line.
+
+    Three components, matched exactly. `0.4` would agree about the release and
+    disagree as a string, which leaves the next reader deciding whether the
+    difference means something.
+    """
+    pyproject = tomllib.loads((REPO / "pyproject.toml").read_text())
+    frontmatter = re.match(
+        r"---\n(.*?)\n---\n", (REPO / "skills" / "slop-writer" / "SKILL.md").read_text(), re.DOTALL
+    )
+    assert frontmatter, "SKILL.md has no YAML frontmatter"
+    declared = re.search(r"^\s+version:\s*[\"']?([^\"'\s]+)[\"']?\s*$", frontmatter.group(1), re.M)
+    assert declared, "SKILL.md's frontmatter declares no metadata.version"
+    assert declared.group(1) == pyproject["project"]["version"], (
+        f"SKILL.md says {declared.group(1)}, pyproject.toml says "
+        f"{pyproject['project']['version']} — a release bumps both"
+    )
 
 
 def test_the_query_path_stays_importable_without_telethon():


### PR DESCRIPTION
Closes #50.

`SKILL.md` declared `metadata.version: "0.4"` against a package `0.4.0` —
agreement about which release, disagreement as a string, and nothing checking
either half. That is the state 0.4.0 shipped in.

## Why the copy stays

The version has to be written where the skill is: `npx skills add` serves the
repository directory and never sees `pyproject.toml`, and nothing derives the
field in either channel — the file is static in both. So `pyproject.toml` is
the source, `SKILL.md` holds the only copy, and a test pins one to the other
byte-for-byte.

## Why a test rather than a convention

Drift here fails nothing at runtime. A missing wheel-data declaration breaks a
user's first `install`; a stale skill version just misreports which release is
on disk, forever and quietly. Through 0.4.0 the two had been aligned by hand
exactly once — #30, resetting the skill's own `1.1 → … → 2.1` counter onto the
package's line. (That counter is also where the stray `v2.1` tag came from.)

Verified by mutation, not just by passing: reverting the field to `0.4` fails
with `SKILL.md says 0.4, pyproject.toml says 0.4.0 — a release bumps both`.

## Three components, not `major.minor`

A coarser "skill contract" version has no reader — npx's lock file has its own
hashing — and a form that differs on purpose is indistinguishable from one that
drifted.

`CLAUDE.md`'s Releases section now says a bump is a two-file edit, which is the
thing the guard makes true.

The second commit is unrelated hygiene: `.claude/worktrees/` holds real
checkouts of this repo, which `git add -A` stages as gitlinks. It did, one
commit ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)