### PR TITLE
fix: what an A/B against the 0.2.0 CLI found

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,461 +1,175 @@
 # tg-scraper / slop-writer
 
-A Claude Code **skill plus an MCP server** that analyze a Telegram channel (the
-author's own [@fastnewsdev](https://t.me/fastnewsdev)). The server's eleven
-tools are the whole agent-facing surface; the skill says which tool answers
-which question and what the numbers mean — **docs/adr/0006** records that move
-and why the CLIs stopped being it. **Two install channels** (#21), both
-serving `skills/slop-writer/` from
-this repository: `uv tool install slop-writer` + `slop-writer install` (which
-copies the skill out of the wheel), and `npx skills@latest add ...`. No drift
-detection — one version covers package and skill, and the last writer wins on
-disk.
+A Claude Code **skill plus an MCP server** that analyze a Telegram channel and
+can queue a post to it. The eleven MCP tools are the whole agent-facing
+surface; the skill under `skills/slop-writer/` says which tool answers which
+question and what the numbers mean. Published to PyPI as `slop-writer`; two
+install channels (`slop-writer install`, `npx skills@latest add …`) serve that
+same skill directory, and one version covers package and skill.
 
-## Layout
+Rationale for a decision lives in `docs/adr/`; vocabulary in `CONTEXT.md`;
+structure (what calls what, where a symbol is) in codegraph.
 
-- `skills/slop-writer/` — the skill itself (read-only when installed). The
-  directory name matches the distribution, and both channels write
-  `.claude/skills/slop-writer/`, so a project never ends up with two copies.
-  **Five files, no `scripts/`** (#21, #30). The seam that decides what goes
-  where is *description = how to call, skill = what it means*, and it is
-  checkable in both directions: **no metric fact in a tool description, no
-  argument name in the skill.** A new tool therefore edits `server.py` and
-  usually nothing here; a new *invariant* edits here and not `server.py`.
-  - `SKILL.md` — the **router** (docs/adr/0005, second iteration): a table from
-    question → tool, the three confusable tool pairs spelled out, and the four
-    invariants that break an answer silently (scrape-before-query, the
-    newest-first bias, one-album-one-post, append-only metrics). It absorbed
-    the separate `tools.md` #15 planned — with the CLI mechanics gone to the
-    server, a router pointing at another router had nothing left in it.
-  - `references/analysis.md` — metric *semantics*: the clauses that decide
-    whether a number is true, the cumulative-snapshot traps, group-scan
-    completeness (the admin log's ~48h retention), and who is who in the group.
-    Was `querying.md`; the SQL mechanics went to the `run_query` description.
-  - `references/schema.md` — restates `SCHEMA` for the SQL-writing agent; read
-    before writing SQL. Reached via `analysis.md`.
-  - `references/publishing.md` — the write discipline and the scheduled queue's
-    semantics (its ids are not post ids, its times are UTC, why the 1h floor
-    has no override). Reached from `SKILL.md`.
-  - `references/markup.md` — supported Markdown→Telegram markup for a post
-    body. Reached via `publishing.md`.
-  There is **no second skill**: `setup-tg-analytic` was deleted by #20 and its
-  whole job is `slop-writer init`. Nothing replaced it — the server's
-  `NO_CREDENTIALS`/`NO_SESSION` hint is the mechanism, and the agent relays it.
-  A thin "setup skill" would recreate the deleted one under a new name.
-- `src/slop_writer/` — the **library, and now the shipped server**, published
-  to PyPI as `slop-writer`. It holds the domain logic; the scripts are argument
-  parsing and output rendering, nothing else, which is what lets `server.py` be
-  a *second caller* of the same functions rather than a rewrite. The scripts
-  name it in their PEP-723 headers (`slop-writer>=0.4,<0.5`), so `uv run`
-  fetches it from the index; nothing is vendored into the skill directory.
-  Modules import each other relatively (`from .db import …`).
-  - `db.py` — paths, the `SCHEMA` + `FTS_SCHEMA` constants (**source of truth**
-    for the DB layout), and DB open helpers. **Stdlib-only**, so importing it
-    doesn't drag Telethon in.
-  - `errors.py` — `SlopWriterError` / `UsageError` (exit 2), carrying
-    `message` / `hint` / `code`. The domain **raises**; each entrypoint decides
-    how to report. Stdlib-only. `ERROR_CODES` is the closed 16-code vocabulary
-    the tool contract promises, **enforced at construction** — a code outside
-    it raises `ValueError`. Its docstring also states the rule for the *prose*
-    half: **a message or a hint names an argument or an operation, never a
-    surface** (#18, generalised by #40) — the string reaches a human at stderr
-    and a model at a tool result, and only one of them has a flag or a script.
-    Two seams cover the case where the surface really does differ, and neither
-    is a raise site: the caller supplies the noun
-    (`prepare_schedule(body_source=…)`) or the boundary swaps the whole hint
-    (`server._SETUP_HINT`).
-  - `query.py` — the read-only SQL guards (`validate_read_only`) and execution
-    (`run_query`, `schema_listing`). **Stdlib-only** with `db.py`, which is
-    what keeps a query answerable without a Telegram client.
-  - `tg.py` — Telethon session/credential plumbing (`_credentials`,
-    `make_client`, `channel_session`, `require_session`, `resolve_peer`,
-    `session_path`). Telethon-dependent, so kept out of stdlib-only `db.py`.
-  - `messages.py` — Telethon `Message` → plain fields (`media_type`,
-    `count_reactions`, `sender_fields`, `group_albums`, `tme_link`). No DB, no
-    network, so `scrape` and `group` share it without importing each other.
-  - `scrape.py` — the post pipeline: `scrape_posts` / `refresh_posts` over one
-    `ingest_with_client` lifecycle, album completion, and the
-    `posts`/`post_metrics` writes.
-  - `group.py` — the discussion group: service/admin-log classification, thread
-    linkage, the `group_messages`/`group_events` writers, and `scan_group`.
-    Imports Telethon (the stdlib-only property went with 0.2.0 — one flat
-    dependency set made it free of value, and `db`/`query` are the modules
-    where it earns its keep). `scrape` imports the row writers here, never the
-    reverse — comments *are* group messages (adr/0002).
-  - `stats.py` — the broadcast-stats API: `fetch_subscribers`,
-    `fetch_views_by_hour`, and the graph decoding both need.
-  - `scheduled.py` — reading the scheduled queue (`list_scheduled`,
-    `get_scheduled_message`). Read-only, and kept out of `publish.py` so the
-    read CLI never imports the module that can post.
-  - `publish.py` — **the write surface** (adr/0003): `prepare_schedule`
-    validates before any session is required, then `schedule_post` /
-    `reschedule_post` / `edit_post`. Nothing on a read path imports it.
-  - `render.py` — pure-presentation Markdown renderers (`summarize_*`); plain
-    dicts in, **a string out** — no Telethon or SQLite types, and no `print`:
-    on a stdio server stdout is the JSON-RPC transport (#16). The CLIs do
-    `print(summarize_x(...))`; one renderer serves both callers. `_handle`
-    is what keeps "both callers" true for the heading: `normalize_channel`
-    strips `@` for *identity* (one channel, one DB file), so display puts it
-    back, and only on a username-shaped label — a title or an invite link is
-    left alone. Two callers that print different headings for one scan is the
-    bug it fixes.
-  - `server.py` — the **MCP server**: `build_server(project_root)` registers
-    all eleven tools, `assert_text_only` is the startup guard, and
-    `WRITE_TOOLS` / `permission_rules()` are the read/write split written down
-    for `install` to copy. Argument parsing and rendering only; no Telegram
-    logic.
-  - `install.py` — `install` / `uninstall`: the **agent wiring** (#19). Knows
-    about MCP clients and nothing about Telegram — no secrets, no TTY, no
-    network. Copies `server.permission_rules()` rather than restating it.
-    It **deletes** `.claude/skills/tg-analytic-skill/`
-    (`LEGACY_SKILL_DIR_NAME`) after copying the current skill — #34's call, on
-    the grounds that #19's "`.claude/` is the human's" rule guards config they
-    authored, and this is our own directory under our former name. Two
-    model-invocable skills claiming one job is not cosmetic: since #30 the
-    stale one advertises CLIs documented nowhere. The delete runs *after* the
-    copy, so a missing skill source cannot leave a machine with no skill at
-    all, and it is always printed. `skills-lock.json` is the opposite call —
-    `_skills_lock_names` reports both our names and **never edits**, because
-    the lock is npx's state file with its own hashing scheme.
-  - `init.py` — `init`: the **Telegram state** (#19). Knows about credentials
-    and sessions and nothing about MCP clients. No `input()` — prompting lives
-    in `cli.py`, which owns the TTY, so these stay testable without one.
-  - `cli.py` — the `slop-writer` console script (argparse, not typer). Decides
-    the project root — from cwd, or `--project` — and loads `.env`. The only
-    module in the package that prompts, prints, or catches `SlopWriterError`.
-  - `markdown.py` — `publish.py` only: walks mistune's Markdown AST straight
-    to Telethon `MessageEntity` objects (no HTML, no sulguk). Tables render as
-    monospace `pre`; UTF-16 offset accounting lives here.
-- `tests/` — the package suite. **`uv run pytest`** (from the repo root; `uv`
-  installs the project editable, so it exercises the working tree). It targets
-  `slop_writer.*` functions and their return shapes, **never** a script's
-  stdout or exit code — the CLI is scheduled to stop being the exercise
-  surface, so a test that asserted on rendered Markdown would be deleted by
-  the MCP move. Where the #15 vocabulary names a failure, assert on
-  `SlopWriterError.code`, not on the message.
-  - `factories.py` holds the faking policy: **messages are real Telethon TL
-    objects** (`complete_albums`/`scan_group` gate on `isinstance`, and
-    Telethon is already a hard dependency), **the client is hand-faked**.
-    Recorded fixtures were rejected — they pin a wire format the `<2` pin
-    already expects to move. One quirk the factories hide: `Message.text` is a
-    property returning `None` until assigned, and every `msg.text or ""` in
-    the package depends on it. `FakeClient` is the whole network boundary
-    (`iter_messages` honouring `reverse`/`limit`/`offset_id`, `get_messages`,
-    `get_entity`, `download_media`, and `__call__` for the three raw TL
-    requests); replies the domain reads through plain `getattr` are duck-typed
-    (`FullChannel`, `AdminLogPage`, `Named`), the ones it `isinstance`-checks
-    are real (`Channel`, `User`, `PublicForwardMessage`).
-  - `test_ingest.py` / `test_group_scan.py` cover the *lifecycles* — the part
-    that orders the units. They call the `*_with_client` functions with a
-    `FakeClient` and a real SQLite file under `tmp_path`, and assert on DB rows
-    and the returned `ScrapeResult`/`GroupScanResult`. `fake_session` exists
-    for exactly one test: that `scrape_posts` resolves the handle before its
-    body opens the DB.
-  - `test_server.py` builds a real `FastMCP` over a `tmp_path` root and asks
-    it questions — the roster, `outputSchema` absence, the `ask`-rules-vs-tool
-    -names comparison, and the write tools' failures up to (never past) the
-    missing session. It is the one place the MCP contract is checked without
-    a client.
-  - `test_server_stdio.py` is the other half: it launches `serve --mcp` as a
-    **subprocess** (cwd = a `tmp_path` project root, no `--project`) and
-    speaks MCP to it, because `isError`, `structuredContent`, `_meta` and the
-    handshake version are produced on the way out and no in-process call runs
-    that code. One session per module, on a loop of its own thread — the suite
-    still has no async plugin. A completed handshake *is* the assertion that
-    `assert_text_only` passed inside the real entrypoint.
-  - `test_errors.py` guards the closed vocabulary two ways: at construction,
-    and **statically over the package's own source** (`ast`, every `code=`
-    literal). The static half exists because most raise sites need a Telegram
-    session to reach, so `__init__`'s check otherwise fires only in a live
-    run. Its `UNREACHED_CODES` ledger is **empty** as of #35 — every code in
-    the vocabulary is named by some raise site — and it survives its emptiness
-    so that re-adding an unreachable code is an edit somebody justifies.
-    `test_tg.py` is the behavioural half for `resolve_peer`'s two codes: the
-    static scan proves a `code=` literal exists, not that the line runs.
-    The same `ast` walk carries the **prose** rule since #40: every `message`
-    and `hint` *literal* is scanned for a CLI flag or a `.py` script name, over
-    the modules `server.py` can reach — a scope **computed from the import
-    graph**, module-level imports only, so `install`/`init`/`cli` fall out as a
-    consequence (their reader is always a human) and a new domain module joins
-    the scan on its own. Interpolated values are skipped on purpose: the dev
-    CLI passing `--file draft.md` through `body_source` is that seam working.
-    It replaced a `test_publish.py` check scoped to one file, which is how the
-    defect survived next door in `scheduled.py`.
-  - Nothing in the suite touches a Telegram session, `.tg-analytic/`, or the
-    network. Live runs stay the acceptance step; they are no longer the only
-    one.
-  - pytest lives in a PEP 735 `[dependency-groups] dev` — never an extra, so
-    it cannot reach a user's install. CI asserts that against the built wheel.
-  - `asyncio.run` via `tests/conftest.py:run`, not pytest-asyncio: four async
-    functions don't justify a plugin whose `asyncio_mode` silently skips tests.
-- `.github/workflows/test.yaml` — push/PR CI: the suite on 3.11 + 3.13, the
-  wheel-metadata guard, and `check_schema_doc.py`. Deliberately **not** part of
-  `publish.yaml`, whose *filename* is bound to PyPI's trusted publisher.
-- `tools/check_schema_doc.py` — **dev-only** drift guard, kept *outside* the
-  skill so it isn't shipped to users; run after editing `SCHEMA` or
-  `references/schema.md`. Its PEP-723 header pins `slop-writer` to *this
-  checkout* (`[tool.uv.sources]`, editable), never to the released version —
-  a guard reading the published schema would pass while the tree disagrees.
-  It stays a standalone script rather than becoming a test: its subject is a
-  document rather than a function, and its editable pin is a different
-  resolution from the suite's. CI runs it as its own step. (The older reason —
-  "a document the package doesn't ship" — expired with #20: the wheel now
-  carries `skills/` so `install` can copy it out.)
-- `tools/tg_scrape.py`, `tools/tg_publish.py`, `tools/tg_query.py` — the
-  original CLIs, **dev-only** since #30 and sharing `tools/`'s "not shipped"
-  property with the guard above. See *The dev CLIs* below.
-- `.tg-analytic/` — **runtime state at the project root** (cwd), gitignored:
-  `.env`, `session.session`, one `<channel>.db` per channel, `media/`. The
-  **entrypoints** anchor this on `Path.cwd()` (`PROJECT_ROOT` at the top of
-  each script; `cli.py` for the server, overridable with `--project`) and pass
-  the derived paths in; `slop_writer` never reads the cwd itself. Always run
-  from the project root — and the MCP client launches `serve` there.
+## Commands
 
-## Stack
+- `uv run pytest` — the suite, from the repo root. `uv` installs the project
+  editable, so it exercises the working tree.
+- `uv run tools/check_schema_doc.py` — dev-only drift guard; run after editing
+  `SCHEMA` or `references/schema.md`. CI runs it as its own step.
+- `uv run --with-editable . tools/tg_*.py` — the dev CLIs against the tree.
+- `slop-writer` (the shipped console script): `install` wires this project's
+  Claude Code config, `uninstall` removes exactly what it wrote, `serve --mcp`
+  runs the server over stdio, `init` writes Telegram credentials and logs in.
+  **`init` needs a TTY for the SMS code — the user runs it, not the agent.**
 
-- Python ≥3.11, run via `uv run` (PEP-723 inline deps in each script header).
-  Shared helpers live in the published `slop-writer` package (`src/`); the CLIs
-  import them as `from slop_writer.x import …`. Each script also declares what
-  it imports *directly* — the package dependency is not a licence to drop them.
-  For local development, pass `--with-editable .` to run against the working
-  tree (it layers over the resolved release; the version pin still has to be
-  satisfiable from the index).
-- **mistune** — `slop_writer.markdown` only: parses the Markdown post body to an AST,
-  which `slop_writer/markdown.py` walks straight to Telethon `MessageEntity` objects (no
-  HTML hop, no sulguk). mistune (CommonMark-ish) over Python-Markdown on
-  purpose: it keeps `#hashtag` lines literal instead of parsing them as `<h1>`,
-  and lets a list interrupt a paragraph without a blank line. Pure-Python, zero
-  transitive deps. Not needed by the read/query scripts. (RichText was a
-  dead-end: it's Instant-View-only — messages carry only text + MessageEntity.)
-- **Telethon** (`>=1.36,<2`) — Telegram client API (not the bot API). Auth = a
-  `session.session` file from a one-time interactive `login` (needs a TTY for
-  the SMS code, so it can't run via the Bash tool — tell the user to run it).
-- **typer** for the PEP-723 scripts — a *script* dependency only, never the
-  library's: the domain raises `SlopWriterError` and the script turns it into
-  stderr + an exit code. `slop_writer.cli` (the shipped `slop-writer` command)
-  uses **argparse** instead, so an installed server carries no CLI framework.
-  **SQLite** for storage (one DB file per channel, leading `@` stripped from
-  the filename). `run_query` opens `?mode=ro`.
-- **mcp** (`>=1.10,<2`) — the Python MCP SDK, `mcp.server.fastmcp`. Pinned
-  below 2 because `structured_output=False` is load-bearing (#16) and v2 moved
-  `FastMCP` elsewhere. **python-dotenv** is a package dependency again as of
-  0.3.0: `serve` decides the project root, so it is one of the callers that
-  populates the environment `tg.py` reads.
-- **Wheel data** — `[tool.uv.build-backend] data = { purelib = "skills" }`
-  ships `skills/slop-writer/` *beside* the package in site-packages, which is
-  how `install` copies it out. It cannot live under `src/slop_writer/`: the
-  same directory is what `npx skills add` serves from the repository root, and
-  uv_build packs only files under the module root — a symlink into `skills/`
-  fails the build outright. `install.skill_source()` tries the source checkout
-  **first**, because an editable install materialises the data directory once
-  at sync time and never refreshes it when a skill file is edited.
+## Library rules (`src/slop_writer/`)
 
-## slop-writer commands
+- **The domain raises, the entrypoint reports.** Nothing under
+  `src/slop_writer/` prints an error or exits: it raises `SlopWriterError`
+  (`UsageError` for exit 2) and `cli.py` or `server.py` decides how to report.
+  That is what lets the server call the same function and build JSON instead.
+- **`errors.ERROR_CODES` is a closed vocabulary**, enforced at construction.
+  Reuse a code; adding one is a deliberate edit with a raise site.
+- **A message or a hint names an argument or an operation, never a surface** —
+  the same string reaches a human at stderr and a model at a tool result, and
+  only one of them has a flag or a script. `tests/test_errors.py` scans every
+  literal statically over the modules `server.py` can reach. When the surface
+  genuinely differs, the caller supplies the noun (`prepare_schedule(
+  body_source=…)`) or the boundary swaps the hint (`server._SETUP_HINT`).
+- **The domain uses a client, the entrypoint owns it.** Scrape and scan paths
+  come in twins: `X_with_client(client, …)` does the work, `X(…, session_file)`
+  wraps it in one `channel_session`. A **new command adds both forms.**
+- **`resolve_peer` runs before any `open_db`** — `open_db` lives inside the
+  `channel_session` body (for the group scan, inside `scan_group_with_client`
+  after `resolve_group_target`). A typo then fails on the handle instead of
+  leaving a stray empty `.tg-analytic/<typo>.db`, and zero posts always means
+  an empty window.
+- **Renderers return a string.** `render.py` takes plain dicts and returns
+  Markdown — no Telethon or SQLite types, and no `print`: on a stdio server
+  stdout is the JSON-RPC transport. The domain returns the result shape
+  (`ScrapeResult`, `GroupScanResult`, …); the entrypoint calls `summarize_*`.
+- `db.py`, `errors.py` and `query.py` stay **stdlib-only** — a query stays
+  answerable without a Telegram client.
+- `publish.py` is the **write surface** (adr/0003); nothing on a read path
+  imports it, which is why `scheduled.py` is separate.
+- **`MESSAGE_TOO_LONG` comes from the network, by design** — the cap depends on
+  the account, so `_too_long` translates Telethon's error rather than measuring
+  the body.
+- **A refusal is not an absence.** `CANNOT_RESOLVE` means the handle names
+  nothing, `NOT_A_MEMBER` means Telegram confirmed the peer and refused this
+  account — one is fixed by correcting the handle, the other by joining. Every
+  new Telethon call that can refuse classifies the two.
+- `cli.py` is **argparse**, so an installed server carries no CLI framework;
+  typer stays a `tools/` script dependency.
+- `.tg-analytic/` is runtime state at the project root (gitignored): `.env`,
+  `session.session`, one `<channel>.db` per channel, `media/`. **Entrypoints**
+  anchor it on the cwd (`--project` overrides); the library never reads the cwd.
 
-The shipped console script.
-
-| Command | Does | Needs |
-| --- | --- | --- |
-| `install` | wire this project's Claude Code config: the path-free `.mcp.json` entry, the permission block, the skill into `.claude/skills/slop-writer/`, the `CLAUDE.md` address block; **deletes a pre-0.4 `.claude/skills/tg-analytic-skill/`** (#34) | nothing — no Telegram, no network |
-| `init` | Telegram credentials → `.tg-analytic/.env`, gitignore, and the TTY login | a real terminal (the user runs it) |
-| `uninstall` | remove exactly what `install` wrote; **never** `.tg-analytic/` | — |
-| `serve --mcp` | run the MCP server over stdio; `--project PATH` overrides the cwd-derived project root | launched by the MCP client, not by hand |
-
-## MCP tools
-
-Eleven tools, server name `slop-writer`, so a permission rule reads
-`mcp__slop-writer__run_query`.
-
-- **Reads** (un-gated): `scrape_posts`, `refresh_posts`, `scan_linked_group`,
-  `scan_standalone_group`, `fetch_subscribers`, `fetch_views_by_hour`,
-  `list_scheduled`, `run_query`.
-- **Telegram writes** (gated): `publish_schedule`, `publish_reschedule`,
-  `publish_edit`.
-
-Non-obvious, and enforced in `server.py`:
+## MCP server (`server.py`)
 
 - **The `publish_` prefix is the read/write split**, not a naming style: Claude
-  Code matches permission rules by tool *name*, and `server.py` imports the
-  read paths and `publish.py` alike — so adr/0003's file-level auditability
-  stops at the module, and the entrypoint's half of it is the name. `install`
-  (#20) writes `permission_rules()` — `allow: [mcp__slop-writer]` plus three
-  `ask` entries — into `.claude/settings.json`; the roster and the rules live
-  in one module because a tool renamed without its rule is silently ungated,
-  and `tests/test_server.py` compares the two halves.
-- `_meta["anthropic/requiresUserInteraction"]` is **rejected** (#15, restated
-  in adr/0003): it survives `bypassPermissions` but makes publishing
-  impossible headless, which forecloses autoposting by the channel's own
-  owner. So a misfire is unlikely, not impossible — `bypassPermissions` walks
-  past an `ask` rule, and nothing in the Claude Code CLI adds permission rules.
-- **The write tools validate before they require a session**, mirroring the
-  CLI: a malformed `at` must answer with the argument to fix, not with
-  "run `slop-writer init`". The empty-body error names `` `body` `` where the
-  CLI names stdin or `--file`.
-
-- **Text only, never `structuredContent`** — Claude Code discards the content
-  blocks when structure is present (#12), so structure travels *inside* text.
-  The SDK's default is the lossy branch, so registration goes through the
-  local `_tool` wrapper (`structured_output=False`) and `assert_text_only`
-  refuses to start a server whose tools carry an `outputSchema`.
+  Code matches permission rules by tool *name*. Roster and `permission_rules()`
+  live in one module because a renamed tool without its rule is silently
+  ungated; `tests/test_server.py` compares the halves.
+- **Text only, never `structuredContent`** — Claude Code drops the content
+  blocks when structure is present, so structure travels *inside* text. Register
+  through the local `_tool` wrapper (`structured_output=False`);
+  `assert_text_only` refuses to start a server whose tools carry an
+  `outputSchema`.
 - **Errors are `{code, message, hint}` JSON in the text block** with
-  `isError: true`, over `errors.ERROR_CODES`. `_guarded` wraps every tool: it
-  translates `SlopWriterError`, names `FLOOD_WAIT` (with `seconds`) at the one
-  place a Telethon flood-wait can be caught once, and turns anything else into
-  `INTERNAL` rather than a traceback. The SDK prefixes the text with
-  `Error executing tool <name>: `; the JSON is the tail.
-- **Two hints belong to the entrypoint, not to the raise site**, which is why
-  `_guarded` is a factory taking the project's `output_dir`: the setup pair
-  answers with `slop-writer init` (`_SETUP_HINT`), and `CANNOT_RESOLVE`
-  answers with `db.scraped_channels()` — the channels this project holds
-  (#43). Both are facts about where the server runs, and the second replaces
-  the domain's "check the handle for typos", which is the wrong remedy for an
-  agent that never had a handle. A hosted server swaps `_resolve_hint` for a
-  tenant lookup and `tg.py` does not move.
-- **Argument validation failures are the one gap**: pydantic rejects a bad
-  `select` arm *before* `_guarded` runs, so those come back as a pydantic
-  message rather than the JSON contract.
-- `select` is a **nested** tagged union (`LatestSelect` / `WindowSelect`, both
-  `extra="forbid"`) — a root-level combinator gets flattened by the client
-  (#23), and nothing validates tool input on the way in.
-- `run_query` alone carries `_meta["anthropic/alwaysLoad"]`; every other tool
-  is deferred behind `ToolSearch`. Its rendered-row default is **50** where the
-  CLI's `--limit` is 100 — different layers, different readers, deliberately
-  not unified.
-- Server `instructions` stay **empty** (#21): they are always in context, so
-  domain knowledge belongs in the skill.
+  `isError: true`. `_guarded` wraps every tool, names `FLOOD_WAIT` (with
+  `seconds`), and labels anything unanticipated `INTERNAL`.
+- **Two hints belong to the entrypoint**, which is why `_guarded` takes the
+  project's `output_dir`: the setup pair answers with `slop-writer init`, and
+  `CANNOT_RESOLVE` answers with the channels this project holds
+  (`db.scraped_channels()`) — an agent that never had a handle cannot fix a typo.
+- **Write tools validate before they require a session** — a malformed `at`
+  answers with the argument to fix, not with "run `slop-writer init`".
+- `select` is a **nested** tagged union (`extra="forbid"` on both arms); a
+  root-level combinator gets flattened by the client. Pydantic rejects a bad arm
+  *before* `_guarded`, so those alone escape the JSON contract.
+- `run_query` alone carries `_meta["anthropic/alwaysLoad"]`; the rest are
+  deferred behind `ToolSearch`.
+- `_meta["anthropic/requiresUserInteraction"]` stays **rejected** and server
+  `instructions` stay **empty** (adr/0003): the first forecloses headless
+  autoposting by the channel's owner, the second is context spent every turn on
+  what belongs in the skill.
+
+## The skill (`skills/slop-writer/`)
+
+Five files, no `scripts/`. The seam is *tool description = how to call, skill =
+what it means*, checkable both ways: **no metric fact in a tool description, no
+argument name in the skill.** A new tool therefore edits `server.py` and usually
+nothing here; a new *invariant* edits here and not `server.py`. `SKILL.md` is a
+router (adr/0005) to `references/{analysis,schema,publishing,markup}.md`.
+
+## Data invariants
+
+- `post_metrics` is **append-only** — `MAX(id)` for "latest snapshot", never
+  `MAX(scrape_date)`. Canonical CTE in `references/schema.md`.
+- **One album = one `posts` row.** `complete_albums` re-fetches missing members
+  before `process_post` picks the head, so a captionless member never becomes a
+  post of its own (a phantom row doubles the album in every `SUM`/`AVG`).
+  `heal_album_phantoms` cleans up rows from pre-fix runs.
+- `group_messages` is the **only** comment store (adr/0002): engagement queries
+  filter `is_thread_root = 0`. `group_events` PK is `(id, user_id)` — one
+  service message can carry several users.
+- **A join count carries its source, or it is unreadable.** Without the admin
+  log the counts are a *floor*, so `scan_group` records whether it read the log
+  in `overview["admin_log"]` and `summarize_group` states it on the line
+  carrying the numbers. **Absent is not `False`** there: a hand-built overview
+  does not know.
+- FTS5 external-content indexes (adr/0004) sync via `FTS_SCHEMA` triggers;
+  `open_db` applies them best-effort (no FTS5 → search lost, scraping fine).
+  `MATCH 'stem*'` is the canonical text search.
+
+## Tests
+
+`slop_writer.*` functions and their return shapes — never a script's stdout or
+exit code. Assert on `SlopWriterError.code`, not on the message. Messages are
+real Telethon TL objects, the client is hand-faked (`factories.FakeClient` is
+the whole network boundary). Nothing in the suite touches a session,
+`.tg-analytic/`, or the network; live runs stay the acceptance step. pytest
+lives in a PEP 735 `dev` group, never an extra.
 
 ## Releases
 
-**A release tag is `vMAJOR.MINOR.PATCH` — nothing else.** `v2.0.0`, `v0.2.1`.
-All three components, always the `v` prefix, no suffix, no two-component form
-(`v2.1` is **not** a release tag), no bare `2.0.0`.
+**A release tag is `vMAJOR.MINOR.PATCH` — nothing else**, equal to `v` + the
+`version` in `pyproject.toml`. **A bump is a two-file edit**: `pyproject.toml`
+and `SKILL.md`'s `metadata.version`, byte-identical, three components — the
+`npx skills add` channel never sees `pyproject.toml`, and
+`tests/test_packaging.py` pins the copy to the source. `publish.yaml` gates on
+tag-vs-`pyproject` agreement but strips the `v`, so the naming rule is a
+convention the gate does not enforce. PyPI versions are immutable: check the tag
+before publishing, not after.
 
-- The tag must equal `v` + the `version` in `pyproject.toml`, which is the
-  **source** of the version (`slop_writer.__version__` reads it back from the
-  installed distribution metadata). One version covers package **and** skill —
-  #21 accepted the drift that buys.
-- **A bump is a two-file edit**: `pyproject.toml` and `SKILL.md`'s
-  `metadata.version`, byte-identical, three components. The skill needs its own
-  copy because the `npx skills add` channel serves the repository directory and
-  never sees `pyproject.toml`, and nothing derives it — the file is static in
-  both channels. `tests/test_packaging.py` pins the copy to the source, which
-  is the only thing standing between a patch release and a skill that
-  misreports which release is on disk. Through 0.4.0 they were aligned by hand
-  exactly once (#30, resetting the skill's own `2.1` counter onto the package's
-  line), and 0.4.0 shipped saying `0.4` — hence the guard.
-- `publish.yaml` gates a release on tag-vs-`pyproject` agreement, but it strips
-  the `v` with `${GITHUB_REF_NAME#v}`, so it accepts a bare `2.0.0` and would
-  accept `v2.1` if `pyproject` said `2.1`. **The naming rule is a convention
-  the gate does not enforce** — a job wanting to enforce it needs its own
-  `case "$GITHUB_REF_NAME" in v[0-9]*.[0-9]*.[0-9]*)` check.
-- PyPI versions are immutable, so a wrong tag is unfixable after upload. Check
-  the tag before publishing the release, not after.
-- Note `v2.1` on the remote: a stray tag on a pre-package commit (`e17f826`),
-  with no release attached and ahead of the real `v0.0.1 → v0.1.0 → v0.2.0`
-  line. It is exactly the shape this rule forbids. Deleting a published tag is
-  the owner's call, not an agent's.
+## Dev CLIs (`tools/tg_*.py`)
 
-## The dev CLIs (`tools/tg_*.py`)
+`tg_scrape.py`, `tg_publish.py`, `tg_query.py` are PEP-723 typer scripts kept as
+**dev tools only** — `login` needs a TTY, and they are the only way to drive
+Telethon without an MCP client. They stay **undocumented**: nothing under
+`skills/` names a script or a flag, and a `grep` is the acceptance check. Flags
+are `--help`; keep it that way rather than restoring a reference file.
 
-`tg_scrape.py` (`login`, `scrape`, `fetch`, `group`, `subscribers`, `views`,
-`scheduled`), `tg_publish.py` (`schedule`, `reschedule`, `edit`) and
-`tg_query.py` are PEP-723 scripts, kept as **dev tools only**. #30 moved them
-out of `skills/slop-writer/` — the skill ships five files and the wheel would
-otherwise post three undocumented CLIs into every user's skill directory.
+`--at` is ISO-8601 **with offset** (naive rejected); the now+1h floor is
+`MIN_LEAD` in `publish.py` with no override, so the agent cannot schedule too
+soon (adr/0003). `reschedule`/`edit` are `editMessage` with `schedule_date`, and
+Telethon returns `None` for scheduled edits — both callers report from known
+inputs. `--caption-above` rides an `invert_media` monkey patch.
 
-They are **undocumented and unsupported**: nothing under `skills/` mentions a
-script name or a flag, and the acceptance check for that is a `grep`. Two
-reasons they survive at all — `login` needs a TTY that `slop-writer init` now
-also provides, and they are the only way to drive Telethon without an MCP
-client. Their flags are `--help`; do not restore a reference file for them.
+## Gotchas
 
-`--at` is ISO-8601 **with offset** (naive rejected); the now+1h floor is a
-hardcoded `MIN_LEAD` in `publish.py`, shared with the tools, with no override —
-the guard exists so the agent can't schedule too soon (docs/adr/0003).
-`reschedule`/`edit` are `editMessage` with `schedule_date`; Telethon returns
-`None` for scheduled edits, so both callers report from known inputs, not from
-the call result. `--caption-above` rides an `invert_media` monkey patch
-(Telethon v1 won't expose it, see #4410).
-
-## Key architecture facts (non-obvious)
-
-- **The domain raises, the entrypoint reports.** No module under
-  `src/slop_writer/` prints an error or exits: it raises `SlopWriterError`
-  (`UsageError` for exit 2) and the CLI turns that into stderr + an exit code.
-  This is what lets the MCP server call the same function and build a JSON
-  payload instead. `code` is the #15 vocabulary, enforced at construction, and
-  every entry in it has a raise site (#35 closed the last two). It stays
-  `None`-able only for the boundary, which labels an unanticipated exception
-  `INTERNAL`.
-- **A refusal is not an absence.** `CANNOT_RESOLVE` means the handle names
-  nothing; `NOT_A_MEMBER` means Telegram confirmed the peer and refused this
-  account. They share a Telethon call and nothing else — one is fixed by
-  correcting the handle, the other by joining — so `resolve_peer` splits
-  `ChannelPrivateError` out, and the group scan classifies the three calls it
-  makes past `resolve_peer` (the linked group's entity, its `full_chat`, and
-  the history read, which can refuse after the other two succeeded). In the
-  linked-group branch a bare `ValueError` counts as membership too: the group's
-  id came from Telegram one call earlier, so it provably exists.
-- **`MESSAGE_TOO_LONG` comes from the network, by design.** The cap depends on
-  the account (1024 UTF-16 units for a caption, 2048 with Premium, 4096 for a
-  text post), so `publish.py` does not measure the body — it translates
-  Telethon's `MessageTooLongError` / `MediaCaptionTooLongError` in `_too_long`,
-  which is therefore the only place the code can be named.
-- **The domain uses a client, the entrypoint owns it.** The scrape and scan
-  paths come in twins: `X_with_client(client, …)` does the work,
-  `X(…, session_file)` is the same call with one `channel_session` wrapped
-  around it (`scrape_posts`, `refresh_posts`, `scan_group` — the CLIs' public
-  signatures, unchanged). A server holding one long-lived client calls the
-  `_with_client` form and never pays for a login per request; a test hands
-  over a fake and no session exists at all. Other paths (`stats`, `scheduled`,
-  `publish`) still open their own session — they get the same split when a
-  caller needs it, not before. A **new command adds both forms.**
-- Handles resolve through `resolve_peer` **before** any `open_db` call, so a
-  typo exits 1 with `Cannot resolve @x` instead of a raw Telethon traceback
-  plus a stray empty `.tg-analytic/<typo>.db`. Keep that order when adding a
-  command; zero scraped posts then means an empty window, never a bad handle.
-  The nesting *is* the invariant: `open_db` lives inside the `channel_session`
-  body. For the group scan it lives one level lower — inside
-  `scan_group_with_client`, after `resolve_group_target`, because a channel's
-  *linked* group is not the channel and only the scan knows which to open.
-- `post_metrics` is **append-only** — use `MAX(id)` for "latest snapshot", not
-  `MAX(scrape_date)`. See the canonical CTE in `references/schema.md`.
-- **One album = one `posts` row.** A selection window can start inside an album,
-  handing the pipeline a *suffix* of it; `complete_albums` re-fetches the
-  missing members by id (≤10 per album, one round-trip) before `process_post`
-  picks the head, so a captionless member never becomes a post of its own. That
-  phantom row was silent — Telegram reports views/forwards on every album
-  member — and doubled the album in every `SUM`/`AVG`. `refresh_posts` passes
-  `window_contiguous=False` because arbitrary ids can't prove an album whole.
-  `heal_album_phantoms` (in `slop_writer/db.py`, run from `open_db` and again after a
-  scrape) deletes rows left by pre-fix runs, and `upsert_post` clears
-  `post_attachments` by `attachment_id` as well as `post_id` so an attachment
-  belongs to exactly one post.
-- Telethon TL types are dynamically generated, so Pyright flags `.sender`,
-  `.chats`, `.full_chat`, `.forwards` etc. as unknown attributes throughout —
-  these warnings are expected noise, not real errors.
-- Every command prints a Markdown summary to stdout designed to be pasted to the
-  user as-is. The domain function **returns** the summary shape (`ScrapeResult`,
-  `GroupScanResult`, …) and the CLI hands it to `summarize_*`; a new command
-  follows that split rather than printing from the library.
-- Full-text search (docs/adr/0004): `posts_fts`/`gm_fts` are FTS5
-  external-content indexes synced by `FTS_SCHEMA` triggers; `open_db` applies
-  `FTS_SCHEMA` best-effort (no FTS5 module → warning, search lost, scraping
-  fine) and backfills via `'rebuild'` only when a table was just created.
-  `MATCH 'stem*'` is the canonical text search (unicode61, no stemming);
-  `schema_listing` hides the `*_fts_*` shadow tables from its error listing.
-- `group_messages` is the **only** comment store (docs/adr/0002 superseded
-  the separate `post_comments` table): `scrape`/`fetch` replace each post's
-  thread (`thread_post_id` = post id), `group` upserts its scan window.
-  Engagement queries always filter `is_thread_root = 0`. `group_events` PK
-  is `(id, user_id)` — one add-user service message can carry several users.
-- **A join count carries its source, or it is unreadable.** Without the admin
-  log the counts are a *floor*, because Telegram suppresses service messages
-  during exactly the join bursts worth counting — so `_fetch_admin_log_events`
-  returns whether it could read the log at all (empty is ambiguous: no
-  membership changes and no admin rights look identical), `scan_group` puts it
-  in `overview["admin_log"]`, and `summarize_group` states it on the line
-  carrying the numbers. It used to live only in a log line, which on a stdio
-  server means a stderr no agent reads. **Absent is not `False`** in that dict:
-  a hand-built overview does not know, and claiming "service messages only"
-  there would be an assertion rather than a default.
+- Telethon TL types are generated dynamically, so Pyright flags `.sender`,
+  `.chats`, `.full_chat`, `.forwards` as unknown attributes throughout —
+  expected noise, not real errors.
+- **mistune**, not Python-Markdown, for a post body: it keeps `#hashtag` lines
+  literal instead of parsing them as `<h1>`. `markdown.py` walks its AST straight
+  to Telethon `MessageEntity` objects (no HTML hop) and owns UTF-16 offsets.
+- Wheel data ships `skills/` *beside* the package (`data = { purelib = "skills" }`)
+  so `install` can copy it out; it cannot live under `src/slop_writer/`, since
+  `npx skills add` serves the same directory from the repo root.
+  `install.skill_source()` tries the source checkout **first** — an editable
+  install materialises the data directory once and never refreshes it.
+- Pins that carry a reason: `mcp>=1.10,<2` (`structured_output=False` is
+  load-bearing and v2 moved `FastMCP`), `telethon>=1.36,<2` (client API, not the
+  bot API).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,12 @@ disk.
   - `render.py` — pure-presentation Markdown renderers (`summarize_*`); plain
     dicts in, **a string out** — no Telethon or SQLite types, and no `print`:
     on a stdio server stdout is the JSON-RPC transport (#16). The CLIs do
-    `print(summarize_x(...))`; one renderer serves both callers.
+    `print(summarize_x(...))`; one renderer serves both callers. `_handle`
+    is what keeps "both callers" true for the heading: `normalize_channel`
+    strips `@` for *identity* (one channel, one DB file), so display puts it
+    back, and only on a username-shaped label — a title or an invite link is
+    left alone. Two callers that print different headings for one scan is the
+    bug it fixes.
   - `server.py` — the **MCP server**: `build_server(project_root)` registers
     all eleven tools, `assert_text_only` is the startup guard, and
     `WRITE_TOOLS` / `permission_rules()` are the read/write split written down
@@ -444,3 +449,13 @@ the call result. `--caption-above` rides an `invert_media` monkey patch
   thread (`thread_post_id` = post id), `group` upserts its scan window.
   Engagement queries always filter `is_thread_root = 0`. `group_events` PK
   is `(id, user_id)` — one add-user service message can carry several users.
+- **A join count carries its source, or it is unreadable.** Without the admin
+  log the counts are a *floor*, because Telegram suppresses service messages
+  during exactly the join bursts worth counting — so `_fetch_admin_log_events`
+  returns whether it could read the log at all (empty is ambiguous: no
+  membership changes and no admin rights look identical), `scan_group` puts it
+  in `overview["admin_log"]`, and `summarize_group` states it on the line
+  carrying the numbers. It used to live only in a log line, which on a stdio
+  server means a stderr no agent reads. **Absent is not `False`** in that dict:
+  a hand-built overview does not know, and claiming "service messages only"
+  there would be an assertion rather than a default.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ channel:
   threads under each.
 - Track **outward forwarders** — outside channels that re-share your posts —
   and **inward citations** — channels you forwarded from.
-- Build an append-only time-series of per-post metrics on every re-run, so you can watch engagement evolve.
-- Pull subscriber growth/churn broken down by acquisition source and views by hour of day for the "best time to post" question.
+- Build an append-only time-series of per-post metrics on every re-run, so you
+  can watch engagement evolve.
+- Pull subscriber growth/churn by acquisition source, and views by hour of day
+  for the "best time to post" question.
 - Schedule, retime, and rewrite future posts — the one write path.
 
 Backed by Telethon. Everything reaches the agent as **MCP tools** — eleven of
@@ -22,12 +24,7 @@ answers questions from.
 
 > This is my personal skill — I built it to manage my own channel,
 > [**@fastnewsdev**](https://t.me/fastnewsdev). It's shared here in case the
-> patterns are useful to someone else running a Telegram channel
-
-> **Renamed from `tg-analytic-skill`.** The analytics are being repackaged as a
-> PyPI distribution driving an MCP server, and the new name leaves room for
-> media beyond Telegram. The setup below is the new one; links to the old
-> repository path still redirect.
+> patterns are useful to someone else running a Telegram channel.
 
 ## Install
 
@@ -39,15 +36,12 @@ slop-writer install     # wires Claude Code: MCP server, permissions, the skill
 slop-writer init        # Telegram credentials and the one-time login
 ```
 
-`install` writes three things: the `slop-writer` entry in `.mcp.json`, a
-permission block in `.claude/settings.json` (reads allowed, publishing behind a
-prompt), and the skill into `.claude/skills/slop-writer/`. It deletes one — a
-`.claude/skills/tg-analytic-skill/` left by a pre-0.4 install, which would
-otherwise load alongside the current skill and describe a surface that no
-longer exists. Everything it writes or removes is printed.
-The `.mcp.json` entry holds no machine-specific path, so it is safe to commit —
-a teammate clones, runs `slop-writer init`, and is done. **Restart your MCP
-client afterwards**: `.mcp.json` is read at session start only.
+`install` writes the `slop-writer` entry in `.mcp.json`, a permission block in
+`.claude/settings.json` (reads allowed, publishing behind a prompt), and the
+skill into `.claude/skills/slop-writer/`; everything it writes is printed. The
+`.mcp.json` entry holds no machine-specific path, so it is safe to commit — a
+teammate clones, runs `slop-writer init`, and is done. **Restart your MCP client
+afterwards**: `.mcp.json` is read at session start only.
 
 Verified on Claude Code. For Cursor, Codex or the Copilot coding agent,
 `install` prints the entry for you to paste into their config yourself.
@@ -57,10 +51,10 @@ Verified on Claude Code. For Cursor, Codex or the Copilot coding agent,
 and runs the login. Run it **in your own terminal** — Telethon prompts for the
 SMS code and 2FA password on stdin, so it cannot go through a tool call. It is
 additive and safe to re-run: it prompts only for what is missing and logs in
-only when there is no working session. The two commands are independent and
-work in either order.
+only when there is no working session. The two commands are independent and work
+in either order.
 
-`slop-writer uninstall` removes exactly what `install` wrote. It never touches
+`slop-writer uninstall` removes exactly what `install` wrote, and never touches
 `.tg-analytic/`.
 
 The skill alone, without the server, still installs through the
@@ -72,10 +66,10 @@ npx skills@latest add Lancetnik/slop-writer
 
 Both channels serve the same directory, so whichever runs last wins on disk.
 
-All runtime state — `.env`, the session, per-channel `*.db` files, downloaded
-media — lives in `.tg-analytic/` at your **project root**, never inside the
-skill. `init` gitignores it for you: the session file is a live login to your
-Telegram account.
+All runtime state — `.env`, the Telethon session, per-channel `*.db` files,
+downloaded media — lives in a gitignored `.tg-analytic/` at your **project
+root**, never inside the skill. `init` gitignores it for you: the session file
+is a live login to your Telegram account.
 
 ## Usage
 
@@ -96,67 +90,26 @@ without dropping into SQL.
 
 `post_metrics` is a time series, but only of the moments you actually scraped —
 it cannot be backfilled. A routine scrape of the latest N posts re-measures
-recent posts only, so an older post can sit on the single snapshot it got on
-its first day forever, and any "how did this post do over time" question then
-has nothing to answer from. Every so often, ask for a refresh over a spread of
-older post ids as well:
+recent posts only, so an older post can sit forever on the single snapshot it
+got on its first day, and "how did this post do over time" then has nothing to
+answer from. Every so often, ask for a refresh over a spread of older ids too:
 
 > Refresh metrics on posts 340, 345, 350 and 355 of @yourchannel.
 
 Views in particular keep climbing for months, so a post's snapshots are worth
 collecting long after it stops feeling current.
 
-The skill's own files, if you want to read what the agent reads:
+## What the agent reads
 
 - [`SKILL.md`](./skills/slop-writer/SKILL.md) — which tool answers which question, and the four invariants that break an answer silently
 - [`references/analysis.md`](./skills/slop-writer/references/analysis.md) — what the numbers mean and how they mislead, over [`references/schema.md`](./skills/slop-writer/references/schema.md)
 - [`references/publishing.md`](./skills/slop-writer/references/publishing.md) — the write discipline and queue semantics, plus [`references/markup.md`](./skills/slop-writer/references/markup.md)
 
-## Repository layout
+## Contributing
 
-```
-skills/
-  slop-writer/        Shipped both ways: packaged into the wheel (so
-                      `slop-writer install` can copy it out) and served to
-                      `npx skills add` from here. One directory, one version.
-    SKILL.md          Which tool answers which question, and the invariants.
-    references/
-      analysis.md     What the numbers mean, and how they mislead.
-      publishing.md   Write discipline and scheduled-queue semantics.
-      schema.md       DB schema reference for writing SQL.
-      markup.md       Supported Markdown -> Telegram markup for post bodies.
-src/
-  slop_writer/        The library and the shipped server, published to PyPI. It
-                      holds the domain logic; `server.py` and the dev CLIs in
-                      `tools/` are argument parsing and output rendering over
-                      it — two callers of one set of functions.
-    db.py             DB schema (source of truth), paths, open helpers. Stdlib only.
-    errors.py         SlopWriterError/UsageError — what the domain raises. Stdlib only.
-    query.py          Read-only SQL guards and execution. Stdlib only.
-    tg.py             Telethon session/credential plumbing.
-    messages.py       Telethon Message -> plain fields (media, reactions, albums).
-    scrape.py         The post pipeline: scrape_posts / refresh_posts.
-    group.py          Discussion group: classification, thread linkage, scan_group.
-    stats.py          Broadcast stats: subscribers, views by hour.
-    scheduled.py      Reading the scheduled queue.
-    publish.py        The write surface: schedule / reschedule / edit.
-    render.py         Markdown renderers for the per-command summaries.
-    markdown.py       Markdown -> Telethon MessageEntity (publish only).
-    server.py         The MCP server and its read tools.
-    install.py        `install`/`uninstall`: the agent wiring. No Telegram.
-    init.py           `init`: credentials, gitignore, the TTY login. No MCP.
-    cli.py            The `slop-writer` console script (argparse).
-tools/               Dev-only, never shipped to users.
-  check_schema_doc.py  Guard SCHEMA <-> references/schema.md drift. Pinned to
-                       this checkout, not to the released package, so it guards
-                       the working tree.
-  tg_scrape.py         The old read CLI (scrape, fetch, group, subscribers,
-  tg_publish.py        views, scheduled), write CLI and SQL CLI. Undocumented
-  tg_query.py          and unsupported: the MCP tools are the surface now.
-                       Kept because `login` needs a TTY and because they are
-                       the only way to exercise Telethon without a client.
-```
-
-Runtime state (`.env`, the Telethon session, per-channel `*.db` files, media)
-lives in a gitignored `.tg-analytic/` directory at the root of whatever
-project you run the skill from — nothing is written inside the skill itself.
+`skills/slop-writer/` is the shipped skill (packaged into the wheel *and* served
+to `npx skills add` from here — one directory, one version). `src/slop_writer/`
+is the library and the MCP server it drives; `tools/` holds dev-only scripts
+that are never shipped. [`CLAUDE.md`](./CLAUDE.md) has the working rules,
+[`CONTEXT.md`](./CONTEXT.md) the vocabulary, and [`docs/adr/`](./docs/adr/) the
+decisions behind both.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slop-writer"
-version = "0.4.0"
+version = "0.4.1"
 description = "Telegram channel analytics as MCP tools: the server behind the slop-writer skill, and the library behind both."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/skills/slop-writer/SKILL.md
+++ b/skills/slop-writer/SKILL.md
@@ -7,7 +7,7 @@ compatibility: >-
 license: Apache-2.0
 metadata:
   author: Lancetnik
-  version: "0.4.0"
+  version: "0.4.1"
 ---
 
 # Telegram channel analytics

--- a/skills/slop-writer/references/analysis.md
+++ b/skills/slop-writer/references/analysis.md
@@ -30,7 +30,7 @@ still returns a number.
 
 `post_metrics` holds what one scan saw, and its counters are running totals:
 `views` is what a post had reached at that moment, not a property of the post.
-Four consequences.
+Five consequences.
 
 **Views grow with no freeze point.** A post keeps collecting views for as long
 as readers scroll past it on the way to newer posts — posts over a year old
@@ -53,6 +53,17 @@ age attached, and a young post's forwards are a floor, not a result.
 gone; nothing can be filled in retroactively. A post with one metrics row
 supports a total, never a trend — check the row count per post before
 reporting change over time.
+
+**A ranking compares snapshots, not posts.** Every row was last measured
+whenever its post happened to be scraped, so a window can hold one post
+measured this morning next to one measured a month ago — and the older
+measurement is the *smaller* one, because views kept arriving after it was
+taken. The order changes accordingly. This is not the age effect above: two
+posts of identical age rank differently depending only on when each was last
+scanned. So before ranking by any rate, run `refresh_posts` over the window
+you are about to rank, then quote the ranking with the measurement date. Skip
+it and two honest runs of the same question return different winners, which
+reads as a broken tool rather than the arithmetic it is.
 
 ## Who is who in the group
 

--- a/skills/slop-writer/references/analysis.md
+++ b/skills/slop-writer/references/analysis.md
@@ -56,10 +56,7 @@ reporting change over time.
 
 **A ranking compares snapshots, not posts.** Each row was measured when its
 post was last scraped, and the staler row is the *smaller* one: views kept
-arriving after it was taken. Two posts of identical age therefore rank by
-scrape recency rather than by performance — a separate effect from age. Run
-`refresh_posts` over a window before ranking it by a rate, or two runs of one
-question return different winners.
+arriving after it was taken. Run `refresh_posts` over a window before ranking it by a rate.
 
 ## Who is who in the group
 

--- a/skills/slop-writer/references/analysis.md
+++ b/skills/slop-writer/references/analysis.md
@@ -54,16 +54,12 @@ gone; nothing can be filled in retroactively. A post with one metrics row
 supports a total, never a trend — check the row count per post before
 reporting change over time.
 
-**A ranking compares snapshots, not posts.** Every row was last measured
-whenever its post happened to be scraped, so a window can hold one post
-measured this morning next to one measured a month ago — and the older
-measurement is the *smaller* one, because views kept arriving after it was
-taken. The order changes accordingly. This is not the age effect above: two
-posts of identical age rank differently depending only on when each was last
-scanned. So before ranking by any rate, run `refresh_posts` over the window
-you are about to rank, then quote the ranking with the measurement date. Skip
-it and two honest runs of the same question return different winners, which
-reads as a broken tool rather than the arithmetic it is.
+**A ranking compares snapshots, not posts.** Each row was measured when its
+post was last scraped, and the staler row is the *smaller* one: views kept
+arriving after it was taken. Two posts of identical age therefore rank by
+scrape recency rather than by performance — a separate effect from age. Run
+`refresh_posts` over a window before ranking it by a rate, or two runs of one
+question return different winners.
 
 ## Who is who in the group
 

--- a/src/slop_writer/group.py
+++ b/src/slop_writer/group.py
@@ -397,11 +397,9 @@ async def _fetch_admin_log_events(
     authoritative join source. Requires admin; degrades to empty with a
     notice otherwise.
 
-    That degradation is why the third element exists. Empty is ambiguous — a
-    group with no membership changes and a group this account may not read the
-    log for produce the same two values — and the difference decides whether
-    the counts are a total or a floor. It used to be resolvable only from a log
-    line, which on a stdio server goes to a stderr nobody reads."""
+    That degradation is why the third element exists: empty is ambiguous — no
+    membership changes and no admin rights return the same two values — and the
+    difference decides whether the counts are a total or a floor."""
     events_filter = ChannelAdminLogEventsFilter(
         join=True, leave=True, invite=True, ban=True, unban=False,
         kick=True, unkick=False, promote=False, demote=False, info=False,
@@ -701,11 +699,9 @@ async def scan_group_with_client(
         "members": target.members,
         "standalone": target.channel_id is None,
         "id_range": f"{lo}..{hi}" if scanned_ids else "—",
-        # Which sources the join/leave counts came from. Not a detail of how
-        # the scan ran: without the admin log the counts are a floor, because
-        # Telegram suppresses service messages during the join bursts a reader
-        # most wants counted. The renderer says so on the line that carries
-        # the numbers.
+        # Where the join/leave counts came from: without the admin log they are
+        # a floor, because Telegram suppresses service messages during the join
+        # bursts most worth counting.
         "admin_log": admin_log,
     }
     messages = [

--- a/src/slop_writer/group.py
+++ b/src/slop_writer/group.py
@@ -386,15 +386,22 @@ async def resolve_group_target(
 
 async def _fetch_admin_log_events(
     client: TelegramClient, entity
-) -> tuple[list[GroupEvent], dict[int, tuple[str | None, str | None]]]:
+) -> tuple[list[GroupEvent], dict[int, tuple[str | None, str | None]], bool]:
     """Joins/leaves from the group's admin log (~48h retention), plus the
-    subjects' (name, username) from the log's own user objects.
+    subjects' (name, username) from the log's own user objects, plus whether
+    the log could be read at all.
 
     The log records membership changes even when Telegram suppresses or
     deletes the corresponding service messages — which is exactly what
     happens to CTA join bursts — so for an admin account it is the
     authoritative join source. Requires admin; degrades to empty with a
-    notice otherwise."""
+    notice otherwise.
+
+    That degradation is why the third element exists. Empty is ambiguous — a
+    group with no membership changes and a group this account may not read the
+    log for produce the same two values — and the difference decides whether
+    the counts are a total or a floor. It used to be resolvable only from a log
+    line, which on a stdio server goes to a stderr nobody reads."""
     events_filter = ChannelAdminLogEventsFilter(
         join=True, leave=True, invite=True, ban=True, unban=False,
         kick=True, unkick=False, promote=False, demote=False, info=False,
@@ -429,14 +436,14 @@ async def _fetch_admin_log_events(
             "admin log unavailable (admin rights needed) - joins/leaves "
             "rely on service messages only (%s)", e,
         )
-        return [], {}
+        return [], {}, False
     if events:
         log.info(
-            "admin log: %d membership event(s) (~48h retention - run "
-            "`group` at least every 2 days to keep the series complete)",
+            "admin log: %d membership event(s) (~48h retention - scan at "
+            "least every 2 days to keep the series complete)",
             len(events),
         )
-    return events, users
+    return events, users, True
 
 
 def _dedupe_admin_events(
@@ -631,7 +638,7 @@ async def scan_group_with_client(
         scanned_ids = [m.id for m in raw]
 
         events = [e for m in service for e in classify_service_message(m)]
-        admin_events, users = await _fetch_admin_log_events(
+        admin_events, users, admin_log = await _fetch_admin_log_events(
             client, target.entity
         )
         if admin_events:
@@ -694,6 +701,12 @@ async def scan_group_with_client(
         "members": target.members,
         "standalone": target.channel_id is None,
         "id_range": f"{lo}..{hi}" if scanned_ids else "—",
+        # Which sources the join/leave counts came from. Not a detail of how
+        # the scan ran: without the admin log the counts are a floor, because
+        # Telegram suppresses service messages during the join bursts a reader
+        # most wants counted. The renderer says so on the line that carries
+        # the numbers.
+        "admin_log": admin_log,
     }
     messages = [
         {

--- a/src/slop_writer/render.py
+++ b/src/slop_writer/render.py
@@ -76,21 +76,15 @@ _USERNAME = re.compile(r"[A-Za-z][A-Za-z0-9_]{4,31}\Z")
 
 
 def _handle(label: str) -> str:
-    """A handle, displayed the way a human writes one: with the `@`.
+    """A handle with its `@`, restored for display.
 
-    The server strips `@` on the way in, because `@chan` and `chan` are one
-    channel (`server.normalize_channel`, #15) and the DB filename is derived
-    from the stripped form. That decision is about *identity*; a heading is
-    display, and dropping the sigil there costs the reader the one character
-    that says this string is a Telegram handle rather than a word.
+    `server.normalize_channel` strips it because `@chan` and `chan` are one
+    channel and the DB filename comes off the stripped form. That is identity;
+    a heading is display, so it comes back here — one place, so the CLI and the
+    server render one line rather than two.
 
-    Restoring it here rather than at each call site is what keeps the two
-    callers agreeing: the CLI passes whatever the user typed, the server passes
-    the normalized form, and both render the same line.
-
-    Anything that is not username-shaped is returned untouched — a group title,
-    a `t.me/...` link, a numeric id. Prefixing those would assert something
-    false."""
+    Username-shaped labels only: a group title, a `t.me/...` link and a numeric
+    id reach the same heading, and prefixing those asserts something false."""
     return f"@{label}" if _USERNAME.fullmatch(label) else label
 
 
@@ -475,11 +469,8 @@ def summarize_group(
     out.append(f"- Joins: {_via_breakdown(events, 'join')}  |  "
                f"Leaves: {_via_breakdown(events, 'leave')}  |  "
                f"net {len(joins) - len(leaves):+d}")
-    # The counts above mean different things depending on what could be read,
-    # and the reader cannot tell the two apart from the numbers. Absent (rather
-    # than False) means a caller built this dict by hand and does not know —
-    # claiming "service messages only" there would be an assertion, not a
-    # default.
+    # Absent (rather than False) means a caller built this dict by hand and does
+    # not know; claiming "service messages only" there would be an assertion.
     if overview.get("admin_log") is None:
         pass
     elif overview["admin_log"]:

--- a/src/slop_writer/render.py
+++ b/src/slop_writer/render.py
@@ -20,6 +20,7 @@ rows instead, a model re-derives that relation on every read and sometimes gets
 it backwards.
 """
 
+import re
 from collections import Counter
 from datetime import UTC, datetime
 
@@ -68,6 +69,31 @@ def _rel_when(iso: str | None, now: datetime) -> str:
     return f"overdue {mag}" if overdue else f"in ~{mag}"
 
 
+#: A Telegram username: 5-32 of [A-Za-z0-9_], starting with a letter. Used to
+#: decide whether a label is a handle worth prefixing, so it is deliberately
+#: strict — a title, a t.me link and a numeric id all fail it.
+_USERNAME = re.compile(r"[A-Za-z][A-Za-z0-9_]{4,31}\Z")
+
+
+def _handle(label: str) -> str:
+    """A handle, displayed the way a human writes one: with the `@`.
+
+    The server strips `@` on the way in, because `@chan` and `chan` are one
+    channel (`server.normalize_channel`, #15) and the DB filename is derived
+    from the stripped form. That decision is about *identity*; a heading is
+    display, and dropping the sigil there costs the reader the one character
+    that says this string is a Telegram handle rather than a word.
+
+    Restoring it here rather than at each call site is what keeps the two
+    callers agreeing: the CLI passes whatever the user typed, the server passes
+    the normalized form, and both render the same line.
+
+    Anything that is not username-shaped is returned untouched — a group title,
+    a `t.me/...` link, a numeric id. Prefixing those would assert something
+    false."""
+    return f"@{label}" if _USERNAME.fullmatch(label) else label
+
+
 def _query_cell(value, truncate: bool = True) -> str:
     if value is None:
         return ""
@@ -111,7 +137,7 @@ def summarize_query(
 
 def summarize_scrape(channel: str, posts: list[dict], channels: list[dict]) -> str:
     """Render an LLM-oriented summary of a scrape run."""
-    out = [f"\n# Scrape summary: {channel}\n"]
+    out = [f"\n# Scrape summary: {_handle(channel)}\n"]
     if not posts:
         out.append("No posts fetched.")
         return "\n".join(out)
@@ -239,7 +265,7 @@ def summarize_scrape(channel: str, posts: list[dict], channels: list[dict]) -> s
 
 def summarize_subscribers(channel: str, rows: dict[str, dict]) -> str:
     """Render an LLM-oriented summary of subscriber dynamics."""
-    out = [f"\n# Subscriber summary: {channel}\n"]
+    out = [f"\n# Subscriber summary: {_handle(channel)}\n"]
     dates = sorted(rows)
     if not dates:
         out.append("No subscriber data.")
@@ -285,7 +311,7 @@ def summarize_subscribers(channel: str, rows: dict[str, dict]) -> str:
 
 def summarize_scheduled(channel: str, items: list[dict]) -> str:
     """Render the scheduled-post queue, one block per post."""
-    out = [f"\n# Scheduled posts: {channel}\n"]
+    out = [f"\n# Scheduled posts: {_handle(channel)}\n"]
     if not items:
         out.append("No scheduled posts in the queue.")
         return "\n".join(out)
@@ -339,7 +365,7 @@ def summarize_schedule(channel: str, item: dict, action: str = "Scheduled") -> s
     now = datetime.now(UTC)
     when = (item.get("date") or "")[:16].replace("T", " ") or "no date"
     rel = _rel_when(item.get("date"), now)
-    out = [f"\n# {action} post: {channel}\n"]
+    out = [f"\n# {action} post: {_handle(channel)}\n"]
     out.append(f"- Publishes: {when} UTC ({rel})")
     if item.get("requested"):
         out.append(f"- Requested: {item['requested']}")
@@ -372,7 +398,7 @@ def summarize_views(
     channel: str, hours: list, views: list, period_start: str, period_end: str
 ) -> str:
     """Render an LLM-oriented summary of views-per-hour."""
-    out = [f"\n# Views by hour of day: {channel}\n"]
+    out = [f"\n# Views by hour of day: {_handle(channel)}\n"]
     pairs = [(int(h), _as_number(v)) for h, v in zip(hours, views)]
     if not pairs:
         out.append("No views-by-hour data.")
@@ -423,7 +449,7 @@ def summarize_group(
     `messages` includes thread roots (is_thread_root=1); every engagement
     figure below excludes them — roots carry the channel post's reactions.
     """
-    out = [f"\n# Group summary: {label}\n"]
+    out = [f"\n# Group summary: {_handle(label)}\n"]
     if not messages and not events:
         out.append("No group messages or events in the scanned window.")
         return "\n".join(out)
@@ -449,6 +475,21 @@ def summarize_group(
     out.append(f"- Joins: {_via_breakdown(events, 'join')}  |  "
                f"Leaves: {_via_breakdown(events, 'leave')}  |  "
                f"net {len(joins) - len(leaves):+d}")
+    # The counts above mean different things depending on what could be read,
+    # and the reader cannot tell the two apart from the numbers. Absent (rather
+    # than False) means a caller built this dict by hand and does not know —
+    # claiming "service messages only" there would be an assertion, not a
+    # default.
+    if overview.get("admin_log") is None:
+        pass
+    elif overview["admin_log"]:
+        out.append("- Event source: admin log (~48h retention) + service "
+                   "messages — complete for that window.")
+    else:
+        out.append("- Event source: service messages only (no admin rights on "
+                   "this group) — **these counts are a floor, not a total**: "
+                   "Telegram suppresses service messages during join bursts, "
+                   "which is exactly when a CTA post is working.")
     if overview.get("standalone"):
         out.append("- Standalone mode: thread linkage skipped.")
 

--- a/src/slop_writer/server.py
+++ b/src/slop_writer/server.py
@@ -310,23 +310,15 @@ async def assert_text_only(mcp: FastMCP) -> None:
 def _complete_sdk_settings_model() -> None:
     """Resolve the SDK's own `Settings` model before anything constructs it.
 
-    `mcp.server.fastmcp.server.Settings` declares `lifespan` with a forward
-    reference it never resolves, so pydantic-settings warns
-    `IncompleteFieldDefinitionWarning` on every `FastMCP(...)` — meaning every
-    server start. On stdio that lands in stderr, which is where the server's
-    own log lines live, so the first thing a reader sees is a five-line warning
-    about somebody else's model.
+    `mcp.server.fastmcp.server.Settings` leaves `lifespan`'s forward reference
+    unresolved, so pydantic-settings warns on every `FastMCP(...)` — every
+    server start — into the stderr our own log lines share. `model_rebuild()`
+    is what the warning asks for and leaves the class correctly defined, where
+    a `filterwarnings` would also hide the same warning about *our* models.
 
-    `model_rebuild()` is the fix the warning itself asks for, and it is not
-    suppression: the class ends up correctly defined rather than quietly
-    broken. Doing it here, at the boundary that owns the SDK, keeps it out of
-    the domain — and out of a `filterwarnings` that would also hide the same
-    warning about *our* models.
-
-    Best-effort by construction: this reaches into another package's private
-    shape, so a moved class costs a noisy stderr and never a failed start. The
-    upstream fix belongs upstream; `mcp` 1.29 is the newest release under the
-    `<2` pin and still carries it."""
+    Best-effort: it reaches into another package's private shape, so a moved
+    class costs a noisy stderr, never a failed start. `mcp` 1.29 is the newest
+    release under the `<2` pin and still carries it."""
     try:
         from mcp.server.fastmcp.server import Settings
 

--- a/src/slop_writer/server.py
+++ b/src/slop_writer/server.py
@@ -307,6 +307,34 @@ async def assert_text_only(mcp: FastMCP) -> None:
         )
 
 
+def _complete_sdk_settings_model() -> None:
+    """Resolve the SDK's own `Settings` model before anything constructs it.
+
+    `mcp.server.fastmcp.server.Settings` declares `lifespan` with a forward
+    reference it never resolves, so pydantic-settings warns
+    `IncompleteFieldDefinitionWarning` on every `FastMCP(...)` — meaning every
+    server start. On stdio that lands in stderr, which is where the server's
+    own log lines live, so the first thing a reader sees is a five-line warning
+    about somebody else's model.
+
+    `model_rebuild()` is the fix the warning itself asks for, and it is not
+    suppression: the class ends up correctly defined rather than quietly
+    broken. Doing it here, at the boundary that owns the SDK, keeps it out of
+    the domain — and out of a `filterwarnings` that would also hide the same
+    warning about *our* models.
+
+    Best-effort by construction: this reaches into another package's private
+    shape, so a moved class costs a noisy stderr and never a failed start. The
+    upstream fix belongs upstream; `mcp` 1.29 is the newest release under the
+    `<2` pin and still carries it."""
+    try:
+        from mcp.server.fastmcp.server import Settings
+
+        Settings.model_rebuild()
+    except Exception:  # pragma: no cover - cosmetic, never load-bearing
+        pass
+
+
 def build_server(project_root: Path) -> FastMCP:
     """The server for one project root.
 
@@ -321,6 +349,7 @@ def build_server(project_root: Path) -> FastMCP:
     output_dir = data_dir(project_root)
     session_file = str(session_path(project_root))
 
+    _complete_sdk_settings_model()
     mcp = FastMCP(name=SERVER_NAME)
     # FastMCP takes no `version`, so `initialize` would otherwise answer with
     # the SDK's — which is the wrong number to read off a bug report. Private

--- a/tests/test_group_scan.py
+++ b/tests/test_group_scan.py
@@ -424,6 +424,21 @@ def test_no_admin_rights_leaves_the_service_messages_standing(tmp_path):
 
     assert rows(tmp_path, "SELECT id, user_id FROM group_events") == [(700, 7)]
     assert len(result.events) == 1
+    # And the reader is told, because 1 join from service messages alone is a
+    # floor: Telegram suppresses them during exactly the bursts worth counting.
+    assert result.overview["admin_log"] is False
+
+
+def test_a_readable_admin_log_is_reported_as_read(tmp_path):
+    """The counterpart: empty is ambiguous on its own. A group with no
+    membership changes and a group whose log this account cannot read both
+    produce zero admin events, and only one of the two makes the counts a
+    total."""
+    client = linked_client([], admin_log=[])
+
+    result = scan(client, tmp_path)
+
+    assert result.overview["admin_log"] is True
 
 
 def test_the_admin_log_is_walked_until_it_returns_nothing(tmp_path):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,69 @@
+"""The renderers, as functions over plain dicts.
+
+`render.py` returns a string rather than printing one (#16), which is what
+makes it testable at all — and what makes these assertions about a *return
+shape*, not about a script's stdout.
+
+Only two properties are pinned here, both found by an A/B run of the CLI
+against the MCP server: the heading has to keep saying which channel it is
+about, and the group summary has to say where its join/leave counts came from.
+Everything else about the layout stays free to move.
+"""
+
+from slop_writer.render import _handle, summarize_group
+
+
+def test_a_bare_handle_renders_with_its_sigil():
+    """The server normalizes `@chan` to `chan` on the way in (#15) because the
+    two are one channel and the DB filename comes off the stripped form. The
+    heading is display, not identity, so it gets the `@` back — otherwise the
+    two callers print different headings for the same scan."""
+    assert _handle("fastnewsdev") == "@fastnewsdev"
+
+
+def test_a_handle_that_already_has_one_is_left_alone():
+    """The CLI passes what the user typed. Idempotence is what lets one
+    renderer serve both callers."""
+    assert _handle("@fastnewsdev") == "@fastnewsdev"
+
+
+def test_what_is_not_a_handle_is_not_decorated():
+    """A group label is not always a username: a title, an invite link and a
+    numeric id all reach the same heading, and prefixing those asserts
+    something false."""
+    assert _handle("FastNews | Chat") == "FastNews | Chat"
+    assert _handle("https://t.me/joinchat/abc") == "https://t.me/joinchat/abc"
+    assert _handle("-1001234567890") == "-1001234567890"
+    assert _handle("abcd") == "abcd"  # 4 chars: below Telegram's minimum
+
+
+def _group(**overview) -> str:
+    return summarize_group(
+        "somegroup",
+        {"title": "Some group", "link": "https://t.me/somegroup", **overview},
+        messages=[{"id": 1, "date": "2026-08-16T10:00:00", "is_thread_root": 0}],
+        events=[{"kind": "join", "via": "added", "date": "2026-08-16T10:00:00"}],
+        threads=[],
+    )
+
+
+def test_counts_read_from_the_admin_log_say_so():
+    assert "admin log" in _group(admin_log=True)
+
+
+def test_counts_without_the_admin_log_are_labelled_a_floor():
+    """The defect this covers was not a wrong number — it was a right number
+    the reader could not qualify. Service messages alone undercount exactly
+    when a CTA post works, because Telegram suppresses them during a join
+    burst, and the summary looked identical either way."""
+    out = _group(admin_log=False)
+    assert "floor" in out
+    assert "service messages only" in out
+
+
+def test_an_unknown_source_claims_nothing():
+    """Absent is not False. A caller that built the overview by hand does not
+    know which case it is in, and a default of "service messages only" would
+    be an assertion rather than a fallback."""
+    out = _group()
+    assert "Event source" not in out


### PR DESCRIPTION
Four findings from a field A/B: the same 11-step scenario driven through the CLI at 0.2.0 and through the MCP server at 0.4.0.

**The data came out clean** — an FTS query byte-identical, forwards and reactions equal to the unit, only cumulative views drifting (+1 in 14 hours). So none of this is about numbers being wrong; all four are about what the summary *says*, which is the only channel an agent actually reads.

## 1. The heading lost the channel

`# Group summary: fastnewsdev` where the CLI said `@fastnewsdev`. `normalize_channel` strips the sigil for **identity** (one channel, one DB file, #15) — a heading is **display**, so it gets it back, in `render._handle` rather than at each call site: the defect was two callers printing different headings for one scan.

Only username-shaped labels are touched. A group title, an invite link and a numeric id all reach the same heading, and prefixing those would assert something false.

The report found three headings. The regression was in **five** — the other two are in tools the scenario does exercise, they just were not diffed — and the fix covers a sixth, `summarize_schedule`, which is unexercised only because the scenario is read-only.

## 2. A join count did not say where it came from

The substantive one. `- Joins: 20 (added 20) | Leaves: 2 (self 2) | net +18` renders identically whether or not the admin log was readable, and the two mean different things: without admin rights Telegram suppresses service messages during a join burst — **exactly when a CTA post is working** — so the count is a floor, not a total.

The distinction existed already, as a log line. On a stdio server that is a stderr no agent reads.

`_fetch_admin_log_events` now returns whether the log could be read at all, because empty was ambiguous: a group with no membership changes and a group this account cannot read the log for produce the same two values. It travels in `overview["admin_log"]` and the summary states it on the line carrying the numbers. **Absent stays distinct from `False`** — a hand-built overview does not know, and defaulting to "service messages only" would be an assertion.

## 3. Ranking by a rate depends on when each row was measured

Two runs of one question agreed on the winner and disagreed on second place, because one refreshed the window first and views had accumulated. Both answers honest.

`analysis.md` already said a rate belongs to the snapshot it came from. What was missing is the operational half, now a fifth consequence: refresh the window before ranking by a rate, then quote the measurement date. It is explicitly *not* framed as "the MCP version is fresher" — one run per arm proves data freshness matters, not that a transport is better.

## 4. pydantic-settings warned on every server start

Five stderr lines about the SDK's own `Settings` model before any line of ours. `model_rebuild()` is the fix the warning asks for and leaves the class correctly defined — unlike a `filterwarnings`, which would also hide the same warning about *our* models. Best-effort by construction: it reaches into another package's private shape, so a moved class costs a noisy stderr, never a failed start. `mcp` 1.29 is the newest release under the `<2` pin and still carries the defect.

Verified against the acceptance criterion: a real `serve --mcp` subprocess now writes **nothing** to stderr before its own logging.

## Tests

349, up 7. New `tests/test_render.py` pins the two properties this found — the heading keeps its channel, the group summary states its event source — and leaves the rest of the layout free to move. `test_group_scan.py` gains the readable-log counterpart, since empty alone proves nothing.

Bumped to **0.4.1** in both files, which is #50's version guard doing its job for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)