### PR TITLE
docs: the release rule names every place the version appears

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,14 +134,15 @@ lives in a PEP 735 `dev` group, never an extra.
 
 ## Releases
 
-**A release tag is `vMAJOR.MINOR.PATCH` — nothing else**, equal to `v` + the
-`version` in `pyproject.toml`. **A bump is a two-file edit**: `pyproject.toml`
-and `SKILL.md`'s `metadata.version`, byte-identical, three components — the
-`npx skills add` channel never sees `pyproject.toml`, and
-`tests/test_packaging.py` pins the copy to the source. `publish.yaml` gates on
-tag-vs-`pyproject` agreement but strips the `v`, so the naming rule is a
-convention the gate does not enforce. PyPI versions are immutable: check the tag
-before publishing, not after.
+**One version string in four places**: `pyproject.toml`'s `version` (the
+source), `SKILL.md`'s `metadata.version`, the git tag (`v` + it), and the
+GitHub release title (the tag verbatim, `v0.4.1`) — three components
+throughout, with the release's prose kept to its notes.
+
+`tests/test_packaging.py` pins the skill's copy to the source, which it needs
+because the `npx skills add` channel never sees `pyproject.toml`. Tag and title
+rest on this convention alone: `publish.yaml` compares them with the `v`
+stripped. PyPI versions are immutable, so check the tag before publishing.
 
 ## Dev CLIs (`tools/tg_*.py`)
 


### PR DESCRIPTION
`v0.4.0` shipped titled **"v0.4.0 — the MCP server"**, where `v0.0.1`, `v0.1.0` and `v0.2.0` are each titled with their bare tag. (Retitled to `v0.4.0` already; only the title moved, never the tag.)

The tag itself was correct. What failed is the sentence: *"A release tag is `vMAJOR.MINOR.PATCH` — nothing else"* scopes to the tag, and a reader has to infer that the GitHub release title is the same string. It reads as a rule about one artifact, and there are four.

So it enumerates them: `pyproject.toml`'s `version`, `SKILL.md`'s `metadata.version`, the tag, the release title — with the concrete instance of each, plus the three forms that are not it.

Naming the four also makes the enforcement gap explicit rather than buried: `tests/test_packaging.py` pins the skill's copy to the source, and **nothing checks the tag or the title**. `publish.yaml` strips the `v` before comparing, so it accepts a malformed tag whose stripped form matches. A convention nothing enforces has to be written where the reader will hit it.

Docs only — no code, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)