### PR TITLE
fix: a selection counts posts, and a short run says why

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,12 @@ router (adr/0005) to `references/{analysis,schema,publishing,markup}.md`.
 
 - `post_metrics` is **append-only** — `MAX(id)` for "latest snapshot", never
   `MAX(scrape_date)`. Canonical CTE in `references/schema.md`.
+- **A selection counts posts, never messages.** Telethon's `limit` counts
+  messages and an album is many messages, so `take_posts` walks an unbounded
+  stream and stops on the first message past the count instead. That is what
+  makes a short run mean exactly one thing — the history ended — which
+  `ScrapeResult.history_exhausted` carries and `summarize_scrape` states.
+  **Absent is not `False`** there either: a refresh walks no window.
 - **One album = one `posts` row.** `complete_albums` re-fetches missing members
   before `process_post` picks the head, so a captionless member never becomes a
   post of its own (a phantom row doubles the album in every `SUM`/`AVG`).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,7 +38,16 @@ the supergroup: the same one is a discussion group once its channel is
 analyzed, so a thread-free record says how it was scanned, not what it is.
 
 **Post**:
-A message published in the channel. Identified by its channel message id.
+A message published in the channel. Identified by its channel message id. An
+album is one post, however many messages carry it — which is why a selection
+is counted in posts and never in messages.
+
+**Exhausted history**:
+A scrape whose walk ran out of channel to read rather than stopping at the
+count it was asked for. The property of one run, not of a channel: the same
+channel is exhausted by a wide window and not by a narrow one. A run that
+walks no window (a refresh of known ids) is neither.
+_Avoid_: complete scrape, full scrape
 
 **Scheduled post**:
 A post queued for Telegram to publish at a future instant, not yet live. Its

--- a/skills/slop-writer/SKILL.md
+++ b/skills/slop-writer/SKILL.md
@@ -75,14 +75,6 @@ the album stays whole — expect log lines about pulled-in members and about
 removed phantom rows, and read both as maintenance, not failure. Never sum a
 metric per album member.
 
-**A scan that comes back short has reached the end of the history.** How many
-posts you ask for is counted in posts, an album included as the one post it
-is, so the only reason to get fewer is that the channel ran out. The summary
-states which of the two it was — a channel read whole, or one window of a
-longer history — and that line, not the number of posts, is what says whether
-anything is left to scan. Asking for more than a channel holds is the cheap
-way to be sure you have all of it.
-
 **Metrics are append-only snapshots.** Every scan appends a row per post
 rather than overwriting one, which is what makes change over time answerable.
 The latest snapshot is the one with the highest row id — *not* the latest

--- a/skills/slop-writer/SKILL.md
+++ b/skills/slop-writer/SKILL.md
@@ -75,6 +75,14 @@ the album stays whole — expect log lines about pulled-in members and about
 removed phantom rows, and read both as maintenance, not failure. Never sum a
 metric per album member.
 
+**A scan that comes back short has reached the end of the history.** How many
+posts you ask for is counted in posts, an album included as the one post it
+is, so the only reason to get fewer is that the channel ran out. The summary
+states which of the two it was — a channel read whole, or one window of a
+longer history — and that line, not the number of posts, is what says whether
+anything is left to scan. Asking for more than a channel holds is the cheap
+way to be sure you have all of it.
+
 **Metrics are append-only snapshots.** Every scan appends a row per post
 rather than overwriting one, which is what makes change over time answerable.
 The latest snapshot is the one with the highest row id — *not* the latest

--- a/src/slop_writer/render.py
+++ b/src/slop_writer/render.py
@@ -129,8 +129,19 @@ def summarize_query(
     return "\n".join(out)
 
 
-def summarize_scrape(channel: str, posts: list[dict], channels: list[dict]) -> str:
-    """Render an LLM-oriented summary of a scrape run."""
+def summarize_scrape(
+    channel: str,
+    posts: list[dict],
+    channels: list[dict],
+    history_exhausted: bool | None = None,
+) -> str:
+    """Render an LLM-oriented summary of a scrape run.
+
+    `history_exhausted` is the difference between "that is the whole channel"
+    and "that is one window of it" — a count alone reads as the first, which
+    is how a walk that stopped at its requested size gets mistaken for a
+    channel with nothing older in it. `None` (a refresh, which walks no
+    window) states neither."""
     out = [f"\n# Scrape summary: {_handle(channel)}\n"]
     if not posts:
         out.append("No posts fetched.")
@@ -151,6 +162,19 @@ def summarize_scrape(channel: str, posts: list[dict], channels: list[dict]) -> s
     out.append("## Overview\n")
     span = f"  ({dates[0][:10]} → {dates[-1][:10]})" if dates else ""
     out.append(f"- Posts: {n}{span}")
+    if history_exhausted is not None:
+        ids = sorted(p["id"] for p in posts)
+        out.append(
+            "- This is the whole channel: the walk reached the end of its "
+            "history, so no posts remain outside this window."
+            if history_exhausted
+            else (
+                f"- This is one window, not the whole channel: the walk "
+                f"stopped at the requested count over ids "
+                f"{ids[0]}–{ids[-1]}, with more history beyond it. Scrape "
+                f"again outside that range to keep going."
+            )
+        )
     out.append(f"- Views: {views:,}  (avg {views // n:,}/post)")
     out.append(f"- Reactions: {reactions:,}   Comments: {comments:,}   "
                f"Forwards of your posts: {forwards:,}")

--- a/src/slop_writer/scrape.py
+++ b/src/slop_writer/scrape.py
@@ -91,10 +91,43 @@ class ScrapeResult:
     """What one run produced, in the shapes `render.summarize_scrape` consumes.
 
     Returned rather than printed: the CLI renders it to stdout, and a second
-    caller can do something else with the same run."""
+    caller can do something else with the same run.
+
+    `history_exhausted` is what makes a short run readable: True means the walk
+    ran out of channel to read, False means it stopped at the requested count
+    with history still beyond it. `None` is "this run did not walk a window" —
+    a refresh of known ids, which can say nothing either way."""
     channel: str
     posts: list[dict]
     channels: list[dict]
+    history_exhausted: bool | None = None
+
+
+async def take_posts(stream, want: int | None) -> tuple[list[Message], bool]:
+    """Read a message stream until `want` *posts* are whole, or it runs dry.
+
+    Telethon's `limit` counts messages, and an album is many messages but one
+    post - so a straight `limit=N` over a channel that posts albums stores
+    fewer than N posts, and the shortfall is indistinguishable from a channel
+    that simply holds no more. Counting posts instead gives a short run exactly
+    one meaning: the history ended. That is the second half of the returned
+    pair, and `summarize_scrape` is what states it.
+
+    Album members carry contiguous ids, so a key the stream has not shown yet
+    closes the previous post: accept every member of the post being read, and
+    stop on the first message of the one past the count. The trailing post is
+    therefore whole on this side; `complete_albums` covers the other one.
+    """
+    raw: list[Message] = []
+    seen: set[tuple[str, int]] = set()
+    async for msg in stream:
+        key = ("album", msg.grouped_id) if msg.grouped_id else ("post", msg.id)
+        if key not in seen:
+            if want is not None and len(seen) >= want:
+                return raw, False
+            seen.add(key)
+        raw.append(msg)
+    return raw, True
 
 
 async def complete_albums(
@@ -644,6 +677,10 @@ async def ingest_with_client(
     `complete_albums` whether the ids around a group can be trusted to prove
     the album is whole (true for a scrape window, false for arbitrary ids).
 
+    A source answers with `(messages, history_exhausted)`: whether the walk ran
+    out of channel is known only to whoever did the walking, and a source that
+    walks no window (a refresh of known ids) says `None` rather than guessing.
+
     The client is a parameter rather than something this function opens, so
     whoever owns the connection decides its lifetime - see the module
     docstring. Callers must have resolved the handle already: `open_db` below
@@ -651,7 +688,7 @@ async def ingest_with_client(
     scrape_date = datetime.now(UTC).isoformat()
     conn = open_db(output_dir, channel)
     try:
-        raw = await source(client, entity)
+        raw, history_exhausted = await source(client, entity)
         post_summaries, channel_summaries = await _persist_messages(
             client, entity, channel, raw, conn, output_dir / "media",
             scrape_date, with_comments, with_media, with_channel_info,
@@ -660,7 +697,9 @@ async def ingest_with_client(
     finally:
         conn.close()
 
-    return ScrapeResult(channel, post_summaries, channel_summaries)
+    return ScrapeResult(
+        channel, post_summaries, channel_summaries, history_exhausted
+    )
 
 
 async def scrape_posts_with_client(
@@ -681,32 +720,41 @@ async def scrape_posts_with_client(
     # most recent N posts. `limit=N` alone keeps the chronological
     # (oldest-first) walk, which is what you want when paging forward from
     # an offset.
+    #
+    # Both counts are *posts*, which is why neither reaches Telethon's `limit`:
+    # `take_posts` walks the unbounded stream and stops on the post past the
+    # count. It reads at most one extra batch, and it is what keeps "fewer than
+    # asked for" meaning "the channel ended" over a channel that posts albums.
     if latest is not None:
         reverse = False
-        iter_limit = latest
+        want = latest
         iter_offset_id = 0
         iter_offset_date = None
     else:
         reverse = True
-        iter_limit = limit
+        want = limit
         # Telethon's offset_id is exclusive; -1 makes offset_id inclusive.
         iter_offset_id = offset_id - 1 if offset_id else 0
         iter_offset_date = offset_date
 
-    async def source(client: TelegramClient, entity) -> list[Message]:
+    async def source(client: TelegramClient, entity) -> tuple[list[Message], bool]:
         log.info("authenticated, scraping %s", channel)
-        raw = [
-            msg
-            async for msg in client.iter_messages(
+        raw, history_exhausted = await take_posts(
+            client.iter_messages(
                 channel,
-                limit=iter_limit,
+                limit=None,
                 reverse=reverse,
                 offset_id=iter_offset_id,
                 offset_date=iter_offset_date,
-            )
-        ]
-        log.info("fetched %d messages", len(raw))
-        return raw
+            ),
+            want,
+        )
+        log.info(
+            "fetched %d messages (history %s)",
+            len(raw),
+            "exhausted" if history_exhausted else "continues past this window",
+        )
+        return raw, history_exhausted
 
     return await ingest_with_client(
         client, entity, channel, output_dir, source,
@@ -726,7 +774,9 @@ async def refresh_posts_with_client(
     with_channel_info: bool = True,
     on_progress: ProgressHook | None = None,
 ) -> ScrapeResult:
-    async def source(client: TelegramClient, entity) -> list[Message]:
+    async def source(
+        client: TelegramClient, entity
+    ) -> tuple[list[Message], None]:
         log.info("authenticated, fetching %d post(s) from %s", len(post_ids), channel)
         # get_messages returns a parallel list; entries are None for missing ids.
         fetched = await client.get_messages(entity, ids=post_ids)
@@ -740,7 +790,8 @@ async def refresh_posts_with_client(
         if missing:
             log.warning("not found in channel: %s", missing)
         log.info("resolved %d/%d post(s)", len(raw), len(post_ids))
-        return raw
+        # No window was walked, so this run knows nothing about what remains.
+        return raw, None
 
     return await ingest_with_client(
         client, entity, channel, output_dir, source,

--- a/src/slop_writer/server.py
+++ b/src/slop_writer/server.py
@@ -172,7 +172,15 @@ class LatestSelect(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     mode: Literal["latest"] = "latest"
-    count: int = Field(100, ge=1, le=5000, description="How many recent posts.")
+    count: int = Field(
+        100,
+        ge=1,
+        le=5000,
+        description=(
+            "How many recent posts. An album counts as one, and fewer than "
+            "this coming back means the channel has no more history."
+        ),
+    )
 
 
 class WindowSelect(BaseModel):
@@ -190,7 +198,13 @@ class WindowSelect(BaseModel):
         None, description="Start after this moment (ISO-8601)."
     )
     limit: int | None = Field(
-        None, ge=1, description="Cap on messages fetched in the walk."
+        None,
+        ge=1,
+        description=(
+            "Cap on posts fetched in the walk. An album counts as one, and "
+            "fewer than this coming back means the walk reached the newest "
+            "post. Omit to read to the end."
+        ),
     )
 
 
@@ -409,7 +423,10 @@ def build_server(project_root: Path) -> FastMCP:
             on_progress=_progress_hook(ctx),
             **_window(select),
         )
-        return summarize_scrape(result.channel, result.posts, result.channels)
+        return summarize_scrape(
+            result.channel, result.posts, result.channels,
+            result.history_exhausted,
+        )
 
     @_tool(
         annotations=local_write,
@@ -440,7 +457,10 @@ def build_server(project_root: Path) -> FastMCP:
             with_channel_info=True,
             on_progress=_progress_hook(ctx),
         )
-        return summarize_scrape(result.channel, result.posts, result.channels)
+        return summarize_scrape(
+            result.channel, result.posts, result.channels,
+            result.history_exhausted,
+        )
 
     @_tool(
         annotations=local_write,

--- a/src/slop_writer/server.py
+++ b/src/slop_writer/server.py
@@ -177,8 +177,8 @@ class LatestSelect(BaseModel):
         ge=1,
         le=5000,
         description=(
-            "How many recent posts. An album counts as one, and fewer than "
-            "this coming back means the channel has no more history."
+            "How many recent posts. An album counts as one, so fewer coming "
+            "back means the channel has no older history."
         ),
     )
 
@@ -201,9 +201,8 @@ class WindowSelect(BaseModel):
         None,
         ge=1,
         description=(
-            "Cap on posts fetched in the walk. An album counts as one, and "
-            "fewer than this coming back means the walk reached the newest "
-            "post. Omit to read to the end."
+            "Cap on posts fetched in the walk. An album counts as one, so "
+            "fewer coming back means the walk reached the newest post."
         ),
     )
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -159,20 +159,26 @@ def test_a_whole_album_becomes_one_post_carrying_every_attachment(tmp_path):
 
 
 def test_a_window_that_cuts_an_album_still_writes_exactly_one_post(tmp_path):
-    """The phantom bug's own shape: `latest=2` hands the pipeline a suffix of
-    a three-member album, and the captionless 10 would have become a post of
-    its own. `complete_albums` pulls 9 back first, so it never does."""
+    """The phantom bug's own shape: an offset landing inside a three-member
+    album hands the pipeline a suffix of it, and the captionless 10 would have
+    become a post of its own. `complete_albums` pulls 9 back first, so it
+    never does.
+
+    The offset is what cuts here. A *count* no longer can: it is counted in
+    posts, so a walk stops on the first message of the post past the count and
+    the album it was reading is whole on that side."""
     client = FakeClient(album(9, 10, 11, caption_on=9))
 
-    do_scrape(client, tmp_path, latest=2, with_media=False, with_channel_info=False)
+    do_scrape(client, tmp_path, offset_id=10, with_media=False,
+              with_channel_info=False)
 
     assert rows(tmp_path, "SELECT id FROM posts") == [(9,)]
     assert rows(
         tmp_path, "SELECT attachment_id FROM post_attachments ORDER BY attachment_id"
     ) == [(9,), (10,), (11,)]
     # The window really was a suffix — 9 arrived through the probe, not the walk.
-    assert client.iter_calls[0]["limit"] == 2
-    assert client.iter_calls[0]["reverse"] is False
+    assert client.iter_calls[0]["offset_id"] == 9
+    assert 9 in client.calls[0]
 
 
 def test_an_attachment_is_taken_off_the_post_that_wrongly_held_it(tmp_path):
@@ -369,6 +375,66 @@ def test_latest_walks_newest_first_and_offset_id_is_inclusive(tmp_path):
     assert sorted(p["id"] for p in paged.posts) == [11, 12]
     assert client.iter_calls[0]["reverse"] is True
     assert client.iter_calls[0]["offset_id"] == 10
+
+
+def test_a_count_counts_posts_not_messages(tmp_path):
+    """The bug: Telethon's `limit` counts messages, so `latest=N` over a
+    channel that posts albums stored fewer than N posts — 100 asked for, 71
+    stored — and the shortfall was indistinguishable from a channel that held
+    no more. Ten messages here are five posts; asking for four must fetch a
+    fifth message rather than stopping at four."""
+    posts = [msg(1, text="a"), msg(2, text="b")]
+    posts += album(3, 4, 5, gid=71, caption_on=3)
+    posts += [msg(6, text="c")]
+    posts += album(7, 8, 9, gid=72, caption_on=7)
+    posts += [msg(10, text="d")]
+
+    result = do_scrape(FakeClient(posts), tmp_path, latest=4,
+                       with_media=False, with_channel_info=False)
+
+    assert [p["id"] for p in result.posts] == [3, 6, 7, 10]
+    assert result.history_exhausted is False
+
+
+def test_a_walk_that_runs_out_of_channel_says_so(tmp_path):
+    """The other half. A count that came back short means one thing now —
+    the history ended — and it has to be stated, or an agent reads the same
+    short answer as "that is the whole channel" either way."""
+    posts = [msg(1, text="a")] + album(2, 3, gid=71, caption_on=2)
+
+    result = do_scrape(FakeClient(posts), tmp_path, latest=50,
+                       with_media=False, with_channel_info=False)
+
+    assert [p["id"] for p in result.posts] == [1, 2]
+    assert result.history_exhausted is True
+
+
+def test_a_window_walk_counts_posts_the_same_way(tmp_path):
+    """Both arms of the selection, one rule. The forward walk pages history,
+    so a `limit` that silently shrank would leave gaps between the pages an
+    agent thought it had covered."""
+    posts = album(1, 2, 3, gid=71, caption_on=1) + [msg(4, text="b"), msg(5, text="c")]
+
+    result = do_scrape(FakeClient(posts), tmp_path, limit=2,
+                       with_media=False, with_channel_info=False)
+
+    assert [p["id"] for p in result.posts] == [1, 4]
+    assert result.history_exhausted is False
+
+
+def test_a_refresh_claims_nothing_about_what_remains(tmp_path):
+    """Absent is not False: a refresh of known ids walks no window, so it
+    cannot say whether history remains, and a `False` here would send an agent
+    paging for more after a run that never looked."""
+    result = run(
+        refresh_posts_with_client(
+            client_with := FakeClient([msg(10, text="here")]), ENTITY, CHANNEL,
+            [10], tmp_path, with_media=False, with_channel_info=False,
+        )
+    )
+
+    assert result.history_exhausted is None
+    assert client_with.iter_calls == []
 
 
 def test_a_refresh_skips_ids_the_channel_no_longer_has(tmp_path, caplog):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -10,7 +10,7 @@ about, and the group summary has to say where its join/leave counts came from.
 Everything else about the layout stays free to move.
 """
 
-from slop_writer.render import _handle, summarize_group
+from slop_writer.render import _handle, summarize_group, summarize_scrape
 
 
 def test_a_bare_handle_renders_with_its_sigil():
@@ -35,6 +35,34 @@ def test_what_is_not_a_handle_is_not_decorated():
     assert _handle("https://t.me/joinchat/abc") == "https://t.me/joinchat/abc"
     assert _handle("-1001234567890") == "-1001234567890"
     assert _handle("abcd") == "abcd"  # 4 chars: below Telegram's minimum
+
+
+def _scrape(history_exhausted) -> str:
+    posts = [
+        {"id": i, "date": "2026-08-16T10:00:00", "link": f"https://t.me/c/1/{i}",
+         "text": "hi", "views": 10}
+        for i in (41, 42)
+    ]
+    return summarize_scrape("chan", posts, [], history_exhausted)
+
+
+def test_a_walk_that_reached_the_end_of_history_says_the_channel_is_whole():
+    assert "whole channel" in _scrape(True)
+
+
+def test_a_walk_that_stopped_at_its_count_says_more_history_remains():
+    """The count alone reads as "that is all there is", which is how a scrape
+    that filled its window got taken for a fully-scraped channel. The ids bound
+    what was covered, so the next window has somewhere to start."""
+    out = _scrape(False)
+    assert "one window, not the whole channel" in out
+    assert "41–42" in out
+
+
+def test_a_run_that_walked_no_window_claims_neither():
+    """Absent is not False — a refresh cannot see past the ids it was given."""
+    out = _scrape(None)
+    assert "whole channel" not in out and "one window" not in out
 
 
 def _group(**overview) -> str:

--- a/tools/tg_scrape.py
+++ b/tools/tg_scrape.py
@@ -169,7 +169,12 @@ def scrape_cmd(
             channel_info,
         )
     )
-    print(summarize_scrape(result.channel, result.posts, result.channels))
+    print(
+        summarize_scrape(
+            result.channel, result.posts, result.channels,
+            result.history_exhausted,
+        )
+    )
 
 
 @app.command("fetch")
@@ -202,7 +207,12 @@ def fetch_cmd(
             channel_info,
         )
     )
-    print(summarize_scrape(result.channel, result.posts, result.channels))
+    print(
+        summarize_scrape(
+            result.channel, result.posts, result.channels,
+            result.history_exhausted,
+        )
+    )
 
 
 @app.command("subscribers")


### PR DESCRIPTION
Closes #54.

## The bug

A scrape asked for 100 posts of an album-heavy channel and stored 71, then
reported `- Posts: 71` and nothing else — so the run read as "this channel has
71 posts" rather than "this window held 71", and the whole channel took a
second scrape nobody knew to run.

Two causes, and the second is what made it expensive:

1. The count reached Telethon as `iter_messages(limit=…)`, which counts
   **messages**. An album is many messages and one post, so the window fetched
   100 messages and stored whatever posts they made.
2. The summary had no way to say which case a run ended in. A walk that filled
   its requested size and a walk that ran out of channel render identically.

## The fix

`take_posts` (scrape.py) walks the unbounded stream and stops on the first
message of the post past the count, so both selection arms — the newest-first
count and the forward window walk — are counted in posts. It reads at most one
extra Telethon batch.

That is what makes the second half possible: a short run now means exactly one
thing, the history ended. `ScrapeResult.history_exhausted` carries it, and
`summarize_scrape` states it on the line under the count:

    - Posts: 100  (2026-03-01 → 2026-08-16)
    - This is one window, not the whole channel: the walk stopped at the
      requested count over ids 102–299, with more history beyond it. Scrape
      again outside that range to keep going.

A refresh of known ids walks no window, so it answers `None` and the summary
claims neither — absent is not False.

## Tests

Five new, at the `scrape_posts_with_client` / `summarize_scrape` seams:
ten messages that are five posts return four posts for a count of four; a
walk that runs out of channel reports exhausted; the window arm counts the
same way; a refresh claims nothing; and the two summary lines.

One existing test changed premise rather than behaviour: a count can no longer
cut an album at its trailing edge (the walk stops on the *next* post's first
message), so `test_a_window_that_cuts_an_album_still_writes_exactly_one_post`
now cuts with an offset landing mid-album, which still does.

`uv run pytest` — 356 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)