### PR TITLE
chore: 0.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slop-writer"
-version = "0.4.2"
+version = "0.4.3"
 description = "Telegram channel analytics as MCP tools: the server behind the slop-writer skill, and the library behind both."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/skills/slop-writer/SKILL.md
+++ b/skills/slop-writer/SKILL.md
@@ -7,7 +7,7 @@ compatibility: >-
 license: Apache-2.0
 metadata:
   author: Lancetnik
-  version: "0.4.2"
+  version: "0.4.3"
 ---
 
 # Telegram channel analytics


### PR DESCRIPTION
Version bump only — the code it releases is already on `main`.

| | |
|---|---|
| `pyproject.toml` | `0.4.2` → `0.4.3` |
| `skills/slop-writer/SKILL.md` | `version: "0.4.2"` → `"0.4.3"` |

## What 0.4.3 carries

- **51e7c8f** `fix: a semicolon inside a literal is not a second statement` —
  the multi-statement guard scanned the body for a bare `;`, so
  `SELECT … WHERE text LIKE '%;%'`, `SELECT 'a;b'` and any query with a
  trailing `-- …; …` comment were refused as multi-statement. The guard exists
  for a clear early error, not for safety (`?mode=ro` is the write barrier), so
  the false refusal closed no hole and cost a valid question — on @fastnewsdev,
  the only query that finds the 10 posts containing a semicolon. Now
  `sqlite3.complete_statement` decides what terminates a statement: stdlib,
  quote- and comment-aware, no SQL parser of our own. Closes #57.
- **bcbf6f2** `feat: the CLI answers which release is installed` — `--version`
  reads the same string the MCP handshake reports and the skill's frontmatter
  copies.

Both are patches, so the third component moves — same call as
"the batch is a patch release, not a minor one" (3e907e6).

## Checks

`uv run pytest` — 372 passed. `tests/test_packaging.py` is the one that pins
the skill's copy to `pyproject.toml`; it needs to, since the `npx skills add`
channel never sees the source.

Tag and release title after merge: `v0.4.3` for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)