### PR TITLE
feat(cli): add support for multiple MCP clients (Codex)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,12 @@
 # tg-scraper / slop-writer
 
-A Claude Code **skill plus an MCP server** that analyze a Telegram channel and
-can queue a post to it. The eleven MCP tools are the whole agent-facing
-surface; the skill under `skills/slop-writer/` says which tool answers which
-question and what the numbers mean. Published to PyPI as `slop-writer`; two
-install channels (`slop-writer install`, `npx skills@latest add …`) serve that
-same skill directory, and one version covers package and skill.
+A **skill plus an MCP server** that analyze a Telegram channel and can queue a
+post to it. The eleven MCP tools are the whole agent-facing surface; the skill
+under `skills/slop-writer/` says which tool answers which question and what the
+numbers mean. Published to PyPI as `slop-writer`; two install channels
+(`slop-writer install`, `npx skills@latest add …`) serve that same skill
+directory, and one version covers package and skill. `install` wires it into a
+**client** — Claude Code or Codex, each independently (adr/0008).
 
 Rationale for a decision lives in `docs/adr/`; vocabulary in `CONTEXT.md`;
 structure (what calls what, where a symbol is) in codegraph.
@@ -18,8 +19,9 @@ structure (what calls what, where a symbol is) in codegraph.
   `SCHEMA` or `references/schema.md`. CI runs it as its own step.
 - `uv run --with-editable . tools/tg_*.py` — the dev CLIs against the tree.
 - `slop-writer` (the shipped console script): `install` wires this project's
-  Claude Code config, `uninstall` removes exactly what it wrote, `serve --mcp`
-  runs the server over stdio, `init` writes Telegram credentials and logs in.
+  client config (`--client claude|codex`, repeatable; bare = claude),
+  `uninstall` removes exactly what it wrote, `serve --mcp` runs the server over
+  stdio, `init` writes Telegram credentials and logs in.
   **`init` needs a TTY for the SMS code — the user runs it, not the agent.**
 
 ## Library rules (`src/slop_writer/`)
@@ -60,7 +62,16 @@ structure (what calls what, where a symbol is) in codegraph.
   account — one is fixed by correcting the handle, the other by joining. Every
   new Telethon call that can refuse classifies the two.
 - `cli.py` is **argparse**, so an installed server carries no CLI framework;
-  typer stays a `tools/` script dependency.
+  typer stays a `tools/` script dependency. `install.py` reads TOML with
+  `tomllib` and writes it with a local emitter for the same reason — no runtime
+  dependency for one config format (adr/0008).
+- **A client is selected, never detected**, and each is wired independently:
+  `install_project`/`uninstall_project` take the selection, return one result
+  per client, and read first-install from *that client's* own config key. A new
+  client adds an installer, an uninstaller and a renderer section — plus its
+  gate emitter in `server.py`. The cross-agent pair (`AGENTS.md` block,
+  `.agents/skills/`) belongs to no client: written on every install, removed
+  only by an unnarrowed uninstall.
 - `.tg-analytic/` is runtime state at the project root (gitignored): `.env`,
   `session.session`, one `<channel>.db` per channel, `media/`. **Entrypoints**
   anchor it on the cwd (`--project` overrides); the library never reads the cwd.
@@ -68,9 +79,12 @@ structure (what calls what, where a symbol is) in codegraph.
 ## MCP server (`server.py`)
 
 - **The `publish_` prefix is the read/write split**, not a naming style: Claude
-  Code matches permission rules by tool *name*. Roster and `permission_rules()`
-  live in one module because a renamed tool without its rule is silently
-  ungated; `tests/test_server.py` compares the halves.
+  Code matches permission rules by tool *name*. Roster, `permission_rules()`
+  and `codex_approval_rules()` live in one module because a renamed tool
+  without its rule is silently ungated; `tests/test_server.py` compares all
+  three. **A new client adds an emitter here, never a translation in
+  `install.py`** (adr/0008) — the module that decides which tools write is the
+  one that says who approves them.
 - **Text only, never `structuredContent`** — Claude Code drops the content
   blocks when structure is present, so structure travels *inside* text. Register
   through the local `_tool` wrapper (`structured_output=False`);
@@ -182,7 +196,16 @@ inputs. `--caption-above` rides an `invert_media` monkey patch.
   so `install` can copy it out; it cannot live under `src/slop_writer/`, since
   `npx skills add` serves the same directory from the repo root.
   `install.skill_source()` tries the source checkout **first** — an editable
-  install materialises the data directory once and never refreshes it.
+  install materialises the data directory once and never refreshes it. **One
+  source, several destinations**: a project holds the skill under
+  `.claude/skills/` *and* `.agents/skills/`, so "one directory" is now true of
+  the source only (adr/0008).
 - Pins that carry a reason: `mcp>=1.10,<2` (`structured_output=False` is
   load-bearing and v2 moved `FastMCP`), `telethon>=1.36,<2` (client API, not the
   bot API).
+
+<!-- slop-writer:start -->
+Telegram channel analytics goes through the `mcp__slop-writer__*` tools.
+Read `.claude/skills/slop-writer/SKILL.md` before calling one — it routes to the metric
+invariants and the DB schema, without which the numbers come back wrong.
+<!-- slop-writer:end -->

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,15 +1,21 @@
 # slop-writer
 
-An MCP server and a Claude Code skill that scrape a Telegram channel into a
-per-channel SQLite DB and answer analytics questions over it. They can also
-queue a future post to the channel (the one write capability; everything else
-only reads).
+An MCP server and a skill that scrape a Telegram channel into a per-channel
+SQLite DB and answer analytics questions over it. They can also queue a future
+post to the channel (the one write capability; everything else only reads).
+`install` wires them into a **client**, of which there is more than one.
 
 ## Language
 
 **Project**:
 The directory the server runs in — one `.tg-analytic/`, and the unit of
 state. Holds any number of scraped channels, one of which is primary.
+
+**Client**:
+The MCP client whose project configuration `install` writes — Claude Code or
+Codex. One project can be wired for more than one, and each is wired
+independently: what a project holds for one client says nothing about another.
+_Avoid_: agent, host, editor, IDE
 
 **Channel**:
 The Telegram broadcast channel being analyzed (e.g. @fastnewsdev). Posts

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
        alt="slop-writer" width="260">
 </picture>
 
-A [Claude Code](https://claude.com/claude-code) skill that analyzes a Telegram
-channel:
+An MCP server and a skill that analyze a Telegram channel, wired into
+[Claude Code](https://claude.com/claude-code) or
+[Codex](https://developers.openai.com/codex/cli) by one command:
 
 - Scrape posts (text, media, reactions, views, forwards, tags) and the comment
   threads under each.
@@ -32,7 +33,7 @@ Two commands, run from the project where you want the analytics.
 
 ```bash
 uv tool install slop-writer
-slop-writer install     # wires Claude Code: MCP server, permissions, the skill
+slop-writer install     # wires Claude Code: MCP server, approval gate, the skill
 slop-writer init        # Telegram credentials and the one-time login
 ```
 
@@ -41,10 +42,39 @@ slop-writer init        # Telegram credentials and the one-time login
 skill into `.claude/skills/slop-writer/`; everything it writes is printed. The
 `.mcp.json` entry holds no machine-specific path, so it is safe to commit — a
 teammate clones, runs `slop-writer init`, and is done. **Restart your MCP client
-afterwards**: `.mcp.json` is read at session start only.
+afterwards**: project configuration is read at session start only.
 
-Verified on Claude Code. For Cursor, Codex or the Copilot coding agent,
-`install` prints the entry for you to paste into their config yourself.
+### Codex, or both
+
+`--client` picks which MCP client gets wired, and it is repeatable:
+
+```bash
+slop-writer install --client codex
+slop-writer install --client claude --client codex
+```
+
+For Codex the equivalents land in one file, `.codex/config.toml`: the
+`[mcp_servers.slop-writer]` entry and, on first install only, an
+`approval_mode = "prompt"` table for each of the three publishing tools. Every
+install also writes an address block into `AGENTS.md` and a copy of the skill
+into `.agents/skills/slop-writer/`, whichever client you named — an agent that
+is neither can still find it.
+
+**Codex ignores a project's configuration until you trust the directory**, and
+that trust lives in your own global config, which this command never writes. So
+a teammate who clones the repository has to answer Codex's trust prompt in the
+directory once; `slop-writer init` is the only other step. The entry itself
+carries no machine-specific path either.
+
+Each client is wired independently: what a project holds for one says nothing
+about another, and "first install" is a property of a client. Cursor and the
+Copilot coding agent are still not written for — their launch directory is
+unverified — so `install` prints an entry for you to paste into their config
+yourself.
+
+`slop-writer uninstall` with no flag removes every client's wiring; narrowed
+with `--client` it leaves the others alone. Neither form ever touches
+`.tg-analytic/`.
 
 `init` asks for your Telegram API credentials
 ([create them here](https://my.telegram.org/apps)), writes `.tg-analytic/.env`,
@@ -53,9 +83,6 @@ SMS code and 2FA password on stdin, so it cannot go through a tool call. It is
 additive and safe to re-run: it prompts only for what is missing and logs in
 only when there is no working session. The two commands are independent and work
 in either order.
-
-`slop-writer uninstall` removes exactly what `install` wrote, and never touches
-`.tg-analytic/`.
 
 The skill alone, without the server, still installs through the
 [`skills`](https://dev.to/baltz/sharing-skills-with-npx-2nbc) CLI:
@@ -73,7 +100,7 @@ is a live login to your Telegram account.
 
 ## Usage
 
-Inside Claude Code, ask in plain language:
+Inside your client, ask in plain language:
 
 > Analyze @some_channel — show me the most popular posts.
 > Who's forwarding @some_channel? Which channels do they cite most often?

--- a/docs/adr/0006-the-shipped-artifact-is-a-package-driving-an-mcp-server.md
+++ b/docs/adr/0006-the-shipped-artifact-is-a-package-driving-an-mcp-server.md
@@ -103,3 +103,27 @@ write gate, 0005 for what the router routes to — so nothing here restates them
   tool description, no argument name in the skill. That is what keeps a new
   tool from re-growing the text this move removed — a description has no room
   for a metric caveat, and the skill has no vocabulary for flags.
+
+## Amended in 0.5 (Lancetnik/slop-writer, the Codex client)
+
+Two sentences above were written when `install` knew one client, and
+[0008](./0008-install-writes-more-than-one-client.md) makes them false as
+written. The decision they belong to is unchanged: the shipped artifact is
+still a package driving an MCP server, and the gate still arrives with the
+distribution rather than as homework. It now arrives for more than one client.
+
+- **"Both install channels serve the same directory into the same
+  `.claude/skills/slop-writer/`"** — still true of those two channels, but
+  `install` writes a second destination as well (`.agents/skills/`, which
+  belongs to no client), so a project holds more than one copy of the skill.
+  "There is one directory to win" no longer holds; one *source* does, and the
+  copies are written from it in one run.
+- **"#19 rejected shipping entries for Cursor, Codex and the Copilot coding
+  agent: their launch cwd is unverified"** — Codex leaves that list. Cursor and
+  the Copilot coding agent stay on it, and the printed entry stays printed and
+  stays labelled unverified.
+
+The claim that the gate "arrives with the distribution" was true of one client
+and homework for every other; 0008 closes that gap rather than overturning it,
+and adds the second emitter beside `permission_rules()` in the module that owns
+the roster — for the same reason the first one lives there.

--- a/docs/adr/0008-install-writes-more-than-one-client.md
+++ b/docs/adr/0008-install-writes-more-than-one-client.md
@@ -1,0 +1,191 @@
+# `install` writes more than one client, and the server module knows both
+
+0.4 shipped one client. `slop-writer install` wrote Claude Code's project
+configuration and, for anyone else, printed a JSON entry to paste by hand.
+That fallback does not work for Codex at all: Codex is configured in TOML, so
+the text on offer could not be pasted anywhere.
+
+The cost of the workaround was not the typing. A Codex user who registered the
+server themselves got the eleven tools with **no gate on the three publishing
+ones** — the human approval that 0006 moved into the distribution went back to
+being homework, and it went back silently. They also got no skill in a
+directory Codex reads, so the agent called the metric tools without the
+invariants that keep the numbers honest.
+
+From 0.5 the command takes a repeatable `--client`, writes each selected
+client's own wiring, and reports what landed for which. This decision records
+the two shapes that a later reader is most likely to try to "fix": the gate
+being emitted from `server.py`, and one project holding several copies of the
+skill.
+
+## The gate is translated in `server.py`, not in `install.py`
+
+`server.py` already owned `WRITE_TOOLS` and `permission_rules()`, because a
+tool renamed without its rule silently loses its gate — the roster and the rule
+are one fact. Codex needs the same fact in a different vocabulary: Claude Code
+matches a rule by the prefixed tool name, Codex matches a bare tool key under
+its own server table.
+
+```toml
+[mcp_servers.slop-writer]
+command = "slop-writer"
+args = ["serve", "--mcp"]
+
+[mcp_servers.slop-writer.tools.publish_schedule]
+approval_mode = "prompt"
+```
+
+So `codex_approval_rules()` is a **sibling of `permission_rules()`**, and the
+suite compares both against the roster and against each other. The obvious
+alternative — a per-client adapter in `install.py`, or a `codex.py` beside it —
+was rejected for the reason the first emitter is where it is: a second module
+is a second place to forget, and a gate that is forgotten fails silently on the
+one client nobody is looking at. The module that decides which tools write is
+the module that says who has to approve them.
+
+`approval_mode` accepts `auto`, `prompt`, `writes` and `approve`; **there is no
+deny value**, so this axis can only put a human in front of a Telegram write.
+Three explicit per-tool tables were chosen over one server-level
+`default_tools_approval_mode = "writes"` because the explicit form names the
+same three tools the roster names, which is what makes the invariant checkable.
+A server-level default names no tool and so checks nothing.
+
+*Open question, from the live run that has not happened yet:* whether `writes`
+reads the MCP `ToolAnnotations` this server already declares. Those annotations
+are empirically inert in Claude Code and set for spec-correctness alone; if
+Codex reads them they are load-bearing on one client and decorative on another.
+Recorded because the answer changes nothing here — the mode was rejected on a
+separate ground — but it is worth knowing.
+
+## Ownership, per client
+
+| artifact | owner | idempotency |
+| --- | --- | --- |
+| `.mcp.json` entry | Claude Code | rewritten every run |
+| `.claude/settings.json` permissions | Claude Code, the human's | first install only |
+| `.claude/skills/<skill>/` | Claude Code | replaced wholesale |
+| `CLAUDE.md` address block | Claude Code, the human's | first install only |
+| `.codex/config.toml` server entry | Codex | rewritten every run |
+| `.codex/config.toml` `tools` tables | Codex, the human's | first install only |
+| `AGENTS.md` address block | no client | written when absent |
+| `.agents/skills/<skill>/` | no client | replaced wholesale |
+
+**Mixed ownership inside one file** is what is new. Claude Code keeps ours and
+theirs in different files; Codex keeps the server entry and the approval
+decisions in the *same* file, and Codex itself writes `approval_mode` there
+when a human answers "don't ask me again". So the two existing policies meet
+inside one file rather than either side of one, and first-install detection —
+still "our own key is absent", still no marker file — is evaluated **per
+client**, since a project can be a first install for one and an upgrade for
+another.
+
+The last two rows belong to no client on purpose. `AGENTS.md` is a cross-agent
+convention rather than Codex's own file, and `.agents/skills/` is the one skill
+root Codex discovers with no config layer involved — so an agent nobody
+installed can still find the skill, and it keeps working in a directory the
+human has not trusted. Only an unnarrowed `uninstall` removes them.
+
+## Selection, never detection
+
+`--client` is repeatable and accepts `claude` and `codex`. Omitted on
+`install` it means `claude` alone, so a project that only ever used one client
+holds exactly what it held before. Omitted on `uninstall` it means every client
+— safe in a way the install default is not, because uninstall only ever removes
+its own markers.
+
+Autodetection was rejected: it would write artifacts nobody asked for, and it
+would leave `uninstall` guessing which of them to take back.
+
+## TOML without a dependency
+
+Reading is `tomllib`, so keys the human wrote survive a merge. Writing is a
+small emitter internal to `install.py` — small only because it emits **our
+tables and nothing else**: the rest of the file is carried across as text, so a
+comment three tables down comes out byte for byte. A parse-and-re-emit round
+trip would need a *general* TOML writer (every type, every nesting) and would
+rewrite the whole file to move one table.
+
+Shelling out to Codex's own CLI was rejected twice over: it writes the global
+config, and it exposes no flag for the approval keys.
+
+The one form the emitter refuses is an entry the human wrote as an inline table
+or a dotted key. Appending our `[table]` header beside it would be a duplicate
+definition, which makes the whole file unreadable to Codex — so `install` names
+the file and stops, the same call `_read_json` makes for corrupt JSON.
+
+## Two things the Codex entry does not say
+
+Both are deliberate omissions rather than oversights, and both are questions
+for the live run rather than for this file.
+
+- **No timeout.** The `.mcp.json` entry carries `timeout = 600000` because a
+  scrape runs for minutes and a killed server mid-ingest is the expensive
+  failure. Codex names and scales that idea differently
+  (`startup_timeout_sec` / `tool_timeout_sec`), and an unverified key in a
+  project layer risks the layer being rejected outright, which would take the
+  gate with it. So the entry is written with `command` and `args` alone and the
+  server inherits Codex's own default. **If a live scrape is cut short, the fix
+  is `tool_timeout_sec` in `codex_server_entry()`** — recorded here so the next
+  reader does not have to rediscover why the two entries disagree.
+- **No `default_tools_approval_mode`.** The three `prompt` tables gate the
+  three writes; the eight reads are unlisted, so they inherit whatever Codex
+  defaults to. That is the half of the read/write split this decision does not
+  *write* — the Claude Code side says `allow` on the whole server explicitly.
+  It was left out because the four modes' semantics are documented by name
+  only, and pinning reads to a value that turns out to mean something else
+  would be worse than inheriting. **"A reading tool call raises no prompt" is a
+  live acceptance check**, and if it fails the answer is a server-level default
+  beside the three tables, not instead of them.
+
+## Accepted costs
+
+- **The one-directory-one-version rule loosens.** A project now holds two
+  copies of the skill — `.claude/skills/` and `.agents/skills/` — and three in
+  a checkout counting the source. 0006 could say "there is one directory to
+  win" because there was; now there are several, and the last writer wins in
+  each. They are written from one source in one run, so they cannot disagree
+  about a *version*; they can disagree only if a human edits one, which
+  `install` already says it overwrites.
+- **One client's entry is committable and the other's is conditional.** Codex
+  disables a project's configuration layer until the human trusts the
+  directory, and the trust lives in *their* global config. So a teammate who
+  clones gets a working `.mcp.json` and a `.codex/config.toml` that stays inert
+  until they answer Codex's trust prompt. Reported by `install`, not worked
+  around: this project does not write another tool's global file.
+- **A managed Codex layer can override the gate without `install` noticing.**
+  The file forms (`/etc/codex/managed_config.toml`, `~/.codex/…`) are checked
+  and refused. The macOS MDM form is a managed *preference* rather than a file
+  and cannot be detected by a path check — and it outranks everything, project
+  layer included. Named here because the refusal above is otherwise easy to
+  read as complete.
+- **The global Codex config is never read for writing and never written.** It
+  is the human's file by the same rule that makes the permission block theirs,
+  and on a real machine it holds other servers' bearer tokens.
+- **A key added *inside* our own entry does not survive an upgrade.** The
+  server entry is rebuilt from `codex_server_entry()` every run and only the
+  `tools` tables are carried across, so an `env` or a timeout a human added
+  under `[mcp_servers.slop-writer]` is gone on the next install. Identical to
+  what `.mcp.json`'s entry has always done, and the same sentence in the report
+  covers it: overwritten every install, and that is the upgrade path.
+
+## What this amends
+
+0006 said the gate "arrives with the distribution instead of being homework".
+That was true of one client and false of every other, which is the gap this
+decision closes rather than a claim it overturns. Two of 0006's sentences no
+longer read as written:
+
+- "both install channels serve the *same* `skills/slop-writer/` directory into
+  the *same* `.claude/skills/slop-writer/`" — still true of those two channels,
+  but `install` now writes a second destination as well. See the cost above.
+- "`install` … rejected shipping entries for Cursor, Codex and the Copilot
+  coding agent: their launch cwd is unverified". Codex leaves that list.
+  **Cursor and the Copilot coding agent stay on it**, and the printed entry
+  stays printed and stays labelled unverified.
+
+The launch-directory question that kept Codex off the list is answered
+conservatively rather than proven: the entry is written path-free, exactly like
+Claude Code's, and `test_the_codex_entry_carries_no_machine_specific_string`
+pins that claim so a live run that contradicts it forces a deliberate change —
+`--project <root>` in the args, and a report that stops calling the entry
+portable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slop-writer"
-version = "0.4.3"
+version = "0.5.0"
 description = "Telegram channel analytics as MCP tools: the server behind the slop-writer skill, and the library behind both."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/skills/slop-writer/SKILL.md
+++ b/skills/slop-writer/SKILL.md
@@ -7,7 +7,7 @@ compatibility: >-
 license: Apache-2.0
 metadata:
   author: Lancetnik
-  version: "0.4.3"
+  version: "0.5.0"
 ---
 
 # Telegram channel analytics

--- a/src/slop_writer/cli.py
+++ b/src/slop_writer/cli.py
@@ -39,7 +39,7 @@ from .init import (
     verify_session,
     write_env,
 )
-from .install import install_project, package_version, uninstall_project
+from .install import CLIENTS, install_project, package_version, uninstall_project
 from .render import summarize_install, summarize_uninstall
 from .server import assert_text_only, build_server
 
@@ -64,12 +64,12 @@ def _project_root(args: argparse.Namespace) -> Path:
 
 
 def _install(args: argparse.Namespace) -> int:
-    print(summarize_install(install_project(_project_root(args))))
+    print(summarize_install(install_project(_project_root(args), args.client)))
     return 0
 
 
 def _uninstall(args: argparse.Namespace) -> int:
-    print(summarize_uninstall(uninstall_project(_project_root(args))))
+    print(summarize_uninstall(uninstall_project(_project_root(args), args.client)))
     return 0
 
 
@@ -218,21 +218,40 @@ def main(argv: list[str] | None = None) -> int:
     def _add_project_flag(p: argparse.ArgumentParser, what: str) -> None:
         p.add_argument("--project", metavar="PATH", help=f"Project root {what}.")
 
+    def _add_client_flag(p: argparse.ArgumentParser, what: str) -> None:
+        # Repeatable rather than comma-separated: one command can wire both,
+        # and `choices` answers a typo with the roster instead of writing
+        # nothing and reporting success.
+        p.add_argument(
+            "--client",
+            action="append",
+            choices=CLIENTS,
+            metavar="NAME",
+            help=f"MCP client to {what}, repeatable "
+            f"({', '.join(CLIENTS)}).",
+        )
+
     install = sub.add_parser(
         "install",
-        help="Wire this project's Claude Code config to the MCP server.",
-        description="Writes the .mcp.json entry, the skill, and — on first "
-        "install only — the permission block and the CLAUDE.md address block. "
-        "Knows nothing about Telegram; run `init` for that, in either order.",
+        help="Wire this project's MCP client config to the server.",
+        description="Writes the client's server entry, the skill, and — on "
+        "first install only — its approval gate and address block, plus the "
+        "cross-agent AGENTS.md block and .agents/skills/ copy whichever client "
+        "was named. Knows nothing about Telegram; run `init` for that, in "
+        "either order.",
     )
     _add_project_flag(install, "to wire (default: the current directory)")
+    _add_client_flag(install, "wire (default: claude)")
     install.set_defaults(func=_install)
 
     uninstall = sub.add_parser(
         "uninstall",
         help="Remove what `install` wrote. Never touches .tg-analytic/.",
+        description="With no --client this removes every client's wiring and "
+        "the cross-agent pair; narrowed to one, it leaves the others alone.",
     )
     _add_project_flag(uninstall, "to unwire (default: the current directory)")
+    _add_client_flag(uninstall, "unwire (default: all of them)")
     uninstall.set_defaults(func=_uninstall)
 
     init = sub.add_parser(

--- a/src/slop_writer/install.py
+++ b/src/slop_writer/install.py
@@ -4,17 +4,38 @@ The contract is Lancetnik/slop-writer#19: this module knows about MCP clients
 and never about Telegram. No credentials, no TTY, no network — which is what
 makes `install` and `init` independent in either order.
 
-Three files get written, with **per-file idempotency** because they have
+**A client is selected, never detected** (adr/0008). `install` writes Claude
+Code unless told otherwise and `--client codex` adds the second; autodetection
+would write artifacts nobody asked for and leave `uninstall` guessing. Each
+client is wired independently, so what a project holds for one says nothing
+about another — first install is a property of a *client*, not of the project.
+
+Written per client, with **per-file idempotency** because the files have
 different owners:
 
-- `.mcp.json` and the skill directory are ours, replaced wholesale every run;
-  that replacement *is* the upgrade path.
-- `.claude/settings.json` and `CLAUDE.md` are the human's, seeded on **first
-  install only** — detected by the absence of our key in `.mcp.json`, so no
-  extra marker file is needed. Someone who deliberately dropped
+- **Claude Code** — `.mcp.json` and `.claude/skills/<skill>/` are ours,
+  replaced wholesale every run; that replacement *is* the upgrade path.
+  `.claude/settings.json` and `CLAUDE.md` are the human's, seeded on **first
+  install only**. Someone who deliberately dropped
   `mcp__slop-writer__publish_schedule` from `ask` (headless autoposting by the
   channel's own owner, the case #15 protected) must not have it restored by an
   upgrade.
+- **Codex** — one file, `.codex/config.toml`, holding both halves: the server
+  entry rewritten every run, the three `tools` approval tables seeded on first
+  install only. Codex writes `approval_mode` into that same file when a human
+  answers "don't ask again", so the two policies meet inside one file rather
+  than either side of one. The **global** Codex config is never read for
+  writing and never written: it is the human's file by the same rule that makes
+  the permission block theirs, and on a real machine it holds other servers'
+  bearer tokens.
+
+Written on **every** install whichever clients were named, because they belong
+to no client: the `AGENTS.md` address block and `.agents/skills/<skill>/`. An
+agent nobody installed can still find the skill. Only an unnarrowed
+`uninstall` removes them.
+
+First install is detected per client from the absence of our own key in that
+client's config, so no marker file is needed on either side.
 
 Nothing here prints: `install_project` / `uninstall_project` return a result
 shape and `render.summarize_install` turns it into text, the same split every
@@ -24,16 +45,28 @@ other command in this package uses.
 import json
 import shutil
 import sysconfig
+import tomllib
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from .db import DATA_DIR_NAME
-from .errors import SlopWriterError
-from .server import SERVER_NAME, permission_rules
+from .errors import SlopWriterError, UsageError
+from .server import SERVER_NAME, codex_approval_rules, permission_rules
+
+#: The clients `install` knows how to wire. Values, not an enum: they are typed
+#: at a command line and compared against argparse `choices`.
+CLAUDE = "claude"
+CODEX = "codex"
+CLIENTS = (CLAUDE, CODEX)
+
+#: What a bare `install` writes. Anything else would change what an upgrade
+#: does to a project that only ever asked for one client.
+DEFAULT_CLIENTS = (CLAUDE,)
 
 #: The skill directory, identical in the repository, in the wheel, and under
-#: `.claude/skills/`. Both install channels (this one and `npx skills add`)
-#: must land on the same path or a project ends up with two copies (#21).
+#: each client's skills parent. Both install channels (this one and `npx skills
+#: add`) must land on the same path or a project ends up with two copies (#21).
 SKILL_DIR_NAME = "slop-writer"
 
 #: What this skill was called before 0.4. A project installed from the old
@@ -50,6 +83,19 @@ SETTINGS_PATH = (".claude", "settings.json")
 SKILLS_PARENT = (".claude", "skills")
 MEMORY_FILE = "CLAUDE.md"
 
+#: Codex reads a project layer from `<dir>/.codex/config.toml` for every
+#: directory between the project root and the cwd, and only once the human has
+#: trusted the directory in their *own* config — which is why the report says
+#: so and `install` does not try to grant it.
+CODEX_CONFIG_PATH = (".codex", "config.toml")
+
+#: The cross-agent pair, owned by no client. `AGENTS.md` is a convention
+#: several agents read; `.agents/skills/` is where Codex discovers repo skills
+#: without any config layer at all, so it keeps working in a directory the
+#: human has not trusted yet.
+AGENTS_FILE = "AGENTS.md"
+AGENTS_SKILLS_PARENT = (".agents", "skills")
+
 #: Markers so `uninstall` can remove exactly what was written and a human can
 #: see where their own text starts.
 BLOCK_START = "<!-- slop-writer:start -->"
@@ -58,8 +104,9 @@ BLOCK_END = "<!-- slop-writer:end -->"
 #: The read/write split, read from `server.py` rather than restated here.
 #: #18 put it next to the roster it matches on purpose: a tool renamed without
 #: its rule silently loses its gate, and this module would be the second place
-#: to forget.
+#: to forget. Both clients' gates come from there for the same reason.
 PUBLISH_TOOLS = tuple(permission_rules()["ask"])
+CODEX_PUBLISH_TOOLS = tuple(codex_approval_rules())
 
 #: Per-server field found by #11 (milliseconds; values under 1000 are ignored).
 #: A scrape runs for minutes, so the default is the wrong bet in the one
@@ -73,6 +120,21 @@ MANAGED_MCP_PATHS = (
     "/etc/claude-code/managed-mcp.json",
     "C:\\ProgramData\\ClaudeCode\\managed-mcp.json",
 )
+
+#: Codex's equivalents. `/etc/codex/` is the Unix path; elsewhere the file
+#: sits in `CODEX_HOME`, which defaults to `~/.codex`. A managed layer does not
+#: merely coexist with the project layer — it **outranks** it, so a gate we
+#: wrote could be overridden by one, which is a stronger reason to refuse than
+#: the symmetry with the check above. The macOS MDM form is a managed
+#: preference rather than a file and is undetectable here (adr/0008).
+MANAGED_CODEX_PATHS = (
+    "/etc/codex/managed_config.toml",
+    "~/.codex/managed_config.toml",
+)
+
+#: Our tables inside Codex's config — the unit `install` replaces and
+#: `uninstall` removes, and the only part of that file either of them touches.
+_CODEX_TABLE = ("mcp_servers", SERVER_NAME)
 
 
 def server_entry() -> dict:
@@ -92,19 +154,37 @@ def server_entry() -> dict:
     }
 
 
-def address_block() -> str:
-    """What a Task-tool subagent is told, and no more.
+def codex_server_entry() -> dict:
+    """The `[mcp_servers.slop-writer]` table, path-free for the same reason.
+
+    Codex's own config vocabulary, not Claude Code's: no `type`, and the
+    timeout keys are named and scaled differently, so nothing is carried over
+    from `server_entry()` on the strength of the two looking alike. What is
+    carried over is the *property* — an entry a teammate can clone and use.
+
+    Committability is weaker on this client than on the other, and not because
+    of this table: Codex ignores a project layer until the human trusts the
+    directory, and that trust lives in their global config. Reported, not
+    worked around."""
+    return {"command": "slop-writer", "args": ["serve", "--mcp"]}
+
+
+def address_block(skill_dir: str) -> str:
+    """What a subagent — or an agent nobody installed — is told, and no more.
 
     Server `instructions` never reach a subagent (#11), and a subagent that
     calls these tools without the metric invariants returns confidently wrong
     numbers. #26 measured which readers actually need this: a custom agent with
     a restricted `tools:` list, granted the MCP tools explicitly — it has no
     skills listing and no `Skill` tool at all, so a skill *name* is a door it
-    cannot open. Hence a file path.
+    cannot open. Hence a file path, and hence a parameter: the same block
+    addresses `.claude/skills/` in `CLAUDE.md` and `.agents/skills/` in
+    `AGENTS.md`, and each file must name the copy its own readers can open.
 
     Not one invariant is copied in. One fact in memory is bait that reads as
-    'the knowledge is here' and stops the subagent fetching the other three."""
-    skill_dir = "/".join((*SKILLS_PARENT, SKILL_DIR_NAME))
+    'the knowledge is here' and stops the subagent fetching the other three.
+    Four lines, because `AGENTS.md` is injected into every turn's instructions
+    from the repository root and every ancestor, under a truncating size cap."""
     return (
         f"{BLOCK_START}\n"
         f"Telegram channel analytics goes through the `mcp__{SERVER_NAME}__*` "
@@ -157,39 +237,110 @@ def package_version() -> str:
 
 
 def managed_mcp_file() -> Path | None:
-    """The enterprise policy file, if this machine has one."""
-    for raw in MANAGED_MCP_PATHS:
-        path = Path(raw)
+    """Claude Code's enterprise policy file, if this machine has one."""
+    return _first_existing(MANAGED_MCP_PATHS)
+
+
+def managed_codex_file() -> Path | None:
+    """Codex's managed configuration layer, if this machine has one."""
+    return _first_existing(MANAGED_CODEX_PATHS)
+
+
+def _first_existing(paths: Iterable[str]) -> Path | None:
+    for raw in paths:
+        path = Path(raw).expanduser()
         if path.is_file():
             return path
     return None
+
+
+def normalize_clients(clients: Sequence[str] | None, default: Sequence[str]) -> tuple[str, ...]:
+    """The selection, de-duplicated in the order it was given.
+
+    A name outside the roster is `UsageError` rather than a silent skip: a
+    client that was asked for and not written is a project the human believes
+    is wired and is not."""
+    selected = default if clients is None else clients
+    unknown = [name for name in selected if name not in CLIENTS]
+    if unknown:
+        # No `code=`: like every other raise in this module, this failure
+        # reaches a human at a terminal and never the tool contract — the
+        # server does not import `install`.
+        raise UsageError(
+            f"Unknown client: {', '.join(unknown)}.",
+            hint=f"Known clients are {', '.join(CLIENTS)}.",
+        )
+    return tuple(dict.fromkeys(selected))
+
+
+@dataclass
+class ClientInstall:
+    """What one client's half of a project now holds.
+
+    One value per client rather than one value with a client's field names:
+    first install, the artifacts written and the "already existed" facts all
+    differ per client, and a single flag would lie in both directions."""
+
+    client: str
+    first_install: bool
+    #: The file holding the server entry.
+    config_file: Path
+    #: The file holding the approval gate — a second file on Claude Code, the
+    #: same file on Codex.
+    gate_file: Path
+    #: Whether this run wrote the gate. False on every run after the first, so
+    #: a human who removed a rule keeps it removed.
+    gate_seeded: bool
+    #: The tool names this version expects behind the gate, in that client's
+    #: spelling.
+    gate_tools: tuple[str, ...]
+    skill_target: Path | None = None
+    skill_existed: bool = False
+    address_file: Path | None = None
+    address_block_written: bool = False
+    #: The pre-0.4 directory this run deleted, or None if there was none (#34).
+    legacy_skill_removed: Path | None = None
 
 
 @dataclass
 class InstallResult:
     project_root: Path
     version: str
-    first_install: bool
-    mcp_config: Path
-    skill_target: Path
-    settings: Path
-    memory_file: Path
-    permissions_seeded: bool
-    memory_block_written: bool
-    skill_existed: bool
-    #: Which of our names `skills-lock.json` tracks — reported, never edited.
+    clients: tuple[ClientInstall, ...]
+    #: The cross-agent pair, written whichever clients were selected.
+    agents_file: Path
+    agents_block_written: bool
+    shared_skill_target: Path
+    shared_skill_existed: bool
+    #: Which of our names a `skills-lock.json` tracks — reported, never edited.
     skills_lock_names: tuple[str, ...]
     on_path: bool
-    #: The pre-0.4 directory this run deleted, or None if there was none (#34).
-    legacy_skill_removed: Path | None = None
-    ask_tools: tuple[str, ...] = PUBLISH_TOOLS
+
+    def for_client(self, client: str) -> ClientInstall | None:
+        return next((c for c in self.clients if c.client == client), None)
+
+
+@dataclass
+class ClientUninstall:
+    client: str
+    removed: list[str] = field(default_factory=list)
 
 
 @dataclass
 class UninstallResult:
     project_root: Path
-    removed: list[str] = field(default_factory=list)
+    clients: tuple[ClientUninstall, ...] = ()
+    #: The cross-agent pair — removed only by an unnarrowed `uninstall`.
+    shared_removed: list[str] = field(default_factory=list)
     kept: list[str] = field(default_factory=list)
+
+    def for_client(self, client: str) -> ClientUninstall | None:
+        return next((c for c in self.clients if c.client == client), None)
+
+
+# --------------------------------------------------------------------------
+# JSON: Claude Code's two files
+# --------------------------------------------------------------------------
 
 
 def _read_json(path: Path) -> dict:
@@ -220,6 +371,234 @@ def _write_json(path: Path, data: dict) -> None:
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
+# --------------------------------------------------------------------------
+# TOML: Codex's one file
+#
+# Read with the standard library, written by the small emitter below — no new
+# runtime dependency, which is the same call `cli.py` made when it took
+# argparse over typer. The emitter only ever writes *our* tables, which is what
+# keeps it small: everything else in the file is carried across as the text the
+# human wrote, comments included.
+# --------------------------------------------------------------------------
+
+
+def _toml_key(name: str) -> str:
+    if name and all((c.isascii() and c.isalnum()) or c in "-_" for c in name):
+        return name
+    return _toml_string(name)
+
+
+def _toml_string(value: str) -> str:
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    return f'"{escaped}"'
+
+
+def _toml_value(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return _toml_string(value)
+    if isinstance(value, int | float):
+        return repr(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_toml_value(item) for item in value) + "]"
+    raise SlopWriterError(
+        f"Cannot write {type(value).__name__} into a Codex configuration.",
+        hint="Remove the value from the `slop-writer` entry by hand, then run "
+        "`slop-writer install` again.",
+    )
+
+
+def _emit_table(path: tuple[str, ...], mapping: dict) -> str:
+    """One table and its sub-tables, in the shape adr/0008 shows.
+
+    A table with sub-tables and no scalars of its own is left out entirely —
+    `[mcp_servers.slop-writer.tools]` says nothing that the three tables under
+    it do not."""
+    scalars = {k: v for k, v in mapping.items() if not isinstance(v, dict)}
+    tables = {k: v for k, v in mapping.items() if isinstance(v, dict)}
+    header = "[" + ".".join(_toml_key(part) for part in path) + "]"
+    blocks = []
+    if scalars or not tables:
+        lines = [header]
+        lines += [f"{_toml_key(k)} = {_toml_value(v)}" for k, v in scalars.items()]
+        blocks.append("\n".join(lines))
+    blocks += [_emit_table((*path, key), sub) for key, sub in tables.items()]
+    return "\n\n".join(blocks)
+
+
+def _parse_key_path(raw: str) -> tuple[str, ...]:
+    """A dotted TOML key, quoted segments included.
+
+    Enough of the grammar to recognise our own table headers under whichever
+    spelling a human used — `[mcp_servers.slop-writer]` or
+    `["mcp_servers"."slop-writer"]` are the same table."""
+    parts: list[str] = []
+    i, n = 0, len(raw)
+    while i < n:
+        while i < n and raw[i] in " \t":
+            i += 1
+        if i >= n:
+            break
+        if raw[i] in "\"'":
+            quote = raw[i]
+            i += 1
+            buf: list[str] = []
+            while i < n and raw[i] != quote:
+                if quote == '"' and raw[i] == "\\" and i + 1 < n:
+                    buf.append(raw[i + 1])
+                    i += 2
+                    continue
+                buf.append(raw[i])
+                i += 1
+            i += 1
+            parts.append("".join(buf))
+        else:
+            start = i
+            while i < n and raw[i] not in ". \t":
+                i += 1
+            parts.append(raw[start:i])
+        while i < n and raw[i] in " \t":
+            i += 1
+        if i < n and raw[i] == ".":
+            i += 1
+    return tuple(part for part in parts if part)
+
+
+def _header_path(line: str) -> tuple[str, ...] | None:
+    """The key path of a `[table]` / `[[array]]` header line, or None."""
+    stripped = line.strip()
+    if not stripped.startswith("["):
+        return None
+    start = 2 if stripped.startswith("[[") else 1
+    quote = None
+    for i in range(start, len(stripped)):
+        char = stripped[i]
+        if quote:
+            if char == quote:
+                quote = None
+            continue
+        if char in "\"'":
+            quote = char
+        elif char == "]":
+            return _parse_key_path(stripped[start:i])
+    return None
+
+
+def _strip_toml_tables(text: str, path: tuple[str, ...]) -> tuple[str, int]:
+    """Remove every table at or under `path`, and nothing else.
+
+    Text surgery rather than a parse-and-re-emit round trip, because the
+    alternative needs a *general* TOML writer — every type, every nesting — and
+    would rewrite the whole file to move one table. This way the only lines
+    that change are ours, and a comment the human wrote three tables down comes
+    out byte for byte."""
+    kept: list[str] = []
+    removed = 0
+    dropping = False
+    for line in text.splitlines():
+        here = _header_path(line)
+        if here is not None:
+            dropping = here[: len(path)] == path
+            if dropping:
+                removed += 1
+                # The blank line that separated our block from what came
+                # before it is ours too; leaving it behind grows the file by
+                # one line per reinstall.
+                while kept and not kept[-1].strip():
+                    kept.pop()
+        if not dropping:
+            kept.append(line)
+    return "\n".join(kept), removed
+
+
+def _read_toml(path: Path) -> dict:
+    """Parse Codex's config, treating a corrupt one as a hard stop — for the
+    same reason `_read_json` does. This file can hold every other MCP server
+    the human registered."""
+    if not path.is_file():
+        return {}
+    try:
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as e:
+        raise SlopWriterError(
+            f"{path} is not valid TOML: {e}",
+            hint="Fix or move the file, then run `slop-writer install` again. "
+            "Overwriting it would drop whatever else it configures.",
+        ) from None
+
+
+def _without_our_entry(config: dict) -> dict:
+    """Everything in a parsed Codex config that is not ours to write."""
+    rest = dict(config)
+    servers = dict(rest.get("mcp_servers") or {})
+    servers.pop(SERVER_NAME, None)
+    if servers:
+        rest["mcp_servers"] = servers
+    else:
+        rest.pop("mcp_servers", None)
+    return rest
+
+
+def _rewritten_codex_config(
+    path: Path, text: str, before: dict, section: dict | None
+) -> str:
+    """The file with our tables replaced by `section`, or removed when None.
+
+    The splice is **proved before it is written**: the result is re-parsed and
+    compared against the original with our own entry taken out of both. Line
+    surgery reads a `[header]` out of the text, and a header-shaped line inside
+    a multi-line string would otherwise make it delete something the human
+    wrote — the one failure that is silent and unrecoverable. A mismatch stops
+    the command with the file untouched."""
+    kept, _ = _strip_toml_tables(text, _CODEX_TABLE)
+    head = kept.strip("\n")
+    body = _emit_table(_CODEX_TABLE, section) if section is not None else ""
+    spliced = ((f"{head}\n\n" if head else "") + body).strip("\n")
+    new_text = f"{spliced}\n" if spliced else ""
+    try:
+        after = tomllib.loads(new_text)
+    except tomllib.TOMLDecodeError:
+        after = None
+    if after is None or _without_our_entry(after) != _without_our_entry(before):
+        raise SlopWriterError(
+            f"{path} cannot be rewritten without changing configuration this "
+            "command does not own.",
+            hint=f"Nothing was written. Remove the `mcp_servers.{SERVER_NAME}` "
+            "tables by hand, then run the command again.",
+        )
+    return new_text
+
+
+def _existing_codex_entry(config: dict, path: Path) -> dict | None:
+    servers = config.get("mcp_servers")
+    if servers is None:
+        return None
+    if not isinstance(servers, dict):
+        raise SlopWriterError(
+            f"{path} has an `mcp_servers` key that is not a table.",
+            hint="Fix it by hand, then run `slop-writer install` again.",
+        )
+    entry = servers.get(SERVER_NAME)
+    if entry is None or isinstance(entry, dict):
+        return entry
+    raise SlopWriterError(
+        f"{path} has an `mcp_servers.{SERVER_NAME}` key that is not a table.",
+        hint="Fix it by hand, then run `slop-writer install` again.",
+    )
+
+
+# --------------------------------------------------------------------------
+# The artifacts
+# --------------------------------------------------------------------------
+
+
 def _seed_permissions(settings_path: Path) -> None:
     """The read/write split from #15, written once.
 
@@ -244,24 +623,29 @@ def _seed_permissions(settings_path: Path) -> None:
     _write_json(settings_path, settings)
 
 
-def _write_memory_block(memory_path: Path) -> None:
-    """Append the address block, creating CLAUDE.md if there is none."""
-    existing = memory_path.read_text(encoding="utf-8") if memory_path.is_file() else ""
+def _write_address_block(address_path: Path, skill_dir: str) -> bool:
+    """Append the address block, creating the file if there is none.
+
+    Returns whether it wrote — an existing block is left exactly where the
+    human moved it to."""
+    existing = address_path.read_text(encoding="utf-8") if address_path.is_file() else ""
     if BLOCK_START in existing:
-        return
+        return False
     separator = "" if not existing or existing.endswith("\n\n") else (
         "\n" if existing.endswith("\n") else "\n\n"
     )
-    memory_path.write_text(
-        existing + separator + address_block() + "\n", encoding="utf-8"
+    address_path.parent.mkdir(parents=True, exist_ok=True)
+    address_path.write_text(
+        existing + separator + address_block(skill_dir) + "\n", encoding="utf-8"
     )
+    return True
 
 
-def _strip_memory_block(memory_path: Path) -> bool:
+def _strip_address_block(address_path: Path) -> bool:
     """Remove our markers and everything between them. Returns whether it hit."""
-    if not memory_path.is_file():
+    if not address_path.is_file():
         return False
-    text = memory_path.read_text(encoding="utf-8")
+    text = address_path.read_text(encoding="utf-8")
     start = text.find(BLOCK_START)
     end = text.find(BLOCK_END)
     if start == -1 or end == -1 or end < start:
@@ -269,7 +653,7 @@ def _strip_memory_block(memory_path: Path) -> bool:
     tail = text[end + len(BLOCK_END) :].lstrip("\n")
     head = text[:start].rstrip("\n")
     joined = f"{head}\n\n{tail}" if head and tail else (head or tail)
-    memory_path.write_text(joined.rstrip("\n") + "\n" if joined else "", encoding="utf-8")
+    address_path.write_text(joined.rstrip("\n") + "\n" if joined else "", encoding="utf-8")
     return True
 
 
@@ -321,9 +705,11 @@ def _skills_lock_names(project_root: Path) -> tuple[str, ...]:
     **Reported, never edited.** The lock is another tool's state file with its
     own hashing scheme; rewriting it means fighting npx for ownership of a
     format we do not control, and a wrong edit corrupts a file we did not
-    write. Naming it is the honest boundary."""
+    write. Naming it is the honest boundary — and the same boundary applies to
+    the cross-agent lock beside `.agents/skills/`, which is why that one is
+    read here too and written nowhere."""
     found = []
-    for name in ("skills-lock.json", ".claude/skills-lock.json"):
+    for name in ("skills-lock.json", ".claude/skills-lock.json", ".agents/skills-lock.json"):
         path = project_root / name
         if not path.is_file():
             continue
@@ -334,14 +720,20 @@ def _skills_lock_names(project_root: Path) -> tuple[str, ...]:
     return tuple(found)
 
 
-def install_project(project_root: Path) -> InstallResult:
-    """Wire this project's Claude Code config to the MCP server.
+# --------------------------------------------------------------------------
+# Per-client install
+#
+# Each client comes in two halves: a `_state` function that reads and refuses,
+# and an installer that writes. `install_project` runs **every** selected
+# client's state function before any of them writes, so a machine-wide policy
+# or a config nobody can parse stops the command with the project untouched
+# rather than after one client was already wired — the same "validate before
+# you act" ordering the write tools use at the server boundary.
+# --------------------------------------------------------------------------
 
-    Claude Code only. #19 rejected shipping entries for Cursor, Codex and the
-    Copilot coding agent: their launch cwd is unverified, and this design rests
-    on cwd being the project root — shipping the untested half means fielding
-    the bug reports for it. `render.summarize_install` prints what those users
-    should paste instead."""
+
+def _claude_state(project_root: Path) -> tuple[Path, dict, dict]:
+    """Claude Code's config, and every reason not to write it."""
     managed = managed_mcp_file()
     if managed is not None:
         raise SlopWriterError(
@@ -359,8 +751,16 @@ def install_project(project_root: Path) -> InstallResult:
             f"{mcp_config} has an `mcpServers` key that is not an object.",
             hint="Fix it by hand, then run `slop-writer install` again.",
         )
+    return mcp_config, config, servers
+
+
+def _install_claude(project_root: Path) -> ClientInstall:
+    """Claude Code's four artifacts, unchanged from 0.4."""
+    mcp_config, config, servers = _claude_state(project_root)
     # First install is read *before* the entry is written — the absence of our
-    # own key is the marker, so nothing extra has to be stored (#19).
+    # own key is the marker, so nothing extra has to be stored (#19), and it is
+    # now read per client, since a project can be a first install for one and
+    # an upgrade for another.
     first_install = SERVER_NAME not in servers
     servers[SERVER_NAME] = server_entry()
     _write_json(mcp_config, config)
@@ -369,29 +769,148 @@ def install_project(project_root: Path) -> InstallResult:
     if first_install:
         _seed_permissions(settings)
 
-    memory_file = project_root / MEMORY_FILE
-    if first_install:
-        _write_memory_block(memory_file)
-
+    address_file = project_root / MEMORY_FILE
     skill_target = project_root / Path(*SKILLS_PARENT) / SKILL_DIR_NAME
+    memory_written = False
+    if first_install:
+        memory_written = _write_address_block(
+            address_file, "/".join((*SKILLS_PARENT, SKILL_DIR_NAME))
+        )
+
     skill_existed = skill_target.exists()
     _copy_skill(skill_target)
     # After the copy, so a failure to find our own skill source leaves the old
     # directory in place rather than removing the only skill on the machine.
     legacy_skill_removed = _remove_legacy_skill(project_root)
 
+    return ClientInstall(
+        client=CLAUDE,
+        first_install=first_install,
+        config_file=mcp_config,
+        gate_file=settings,
+        gate_seeded=first_install,
+        gate_tools=PUBLISH_TOOLS,
+        skill_target=skill_target,
+        skill_existed=skill_existed,
+        address_file=address_file,
+        address_block_written=memory_written,
+        legacy_skill_removed=legacy_skill_removed,
+    )
+
+
+def _codex_state(project_root: Path) -> tuple[Path, str, dict, dict | None]:
+    """Codex's config as text and as a parse, and every reason not to write it.
+
+    Reading it twice — once here to refuse, once in the installer to write — is
+    the price of refusing before *any* client is touched. The file is small and
+    both reads go through the same two functions, so there is one place where a
+    refusal can be added."""
+    managed = managed_codex_file()
+    if managed is not None:
+        raise SlopWriterError(
+            f"Codex configuration on this machine is managed by {managed}.",
+            hint="A managed layer outranks a project's own configuration, so "
+            "the approval gate this command writes could be overridden "
+            "without notice. Ask whoever administers it to add "
+            "`slop-writer`; re-running this command cannot help.",
+        )
+
+    config_file = project_root / Path(*CODEX_CONFIG_PATH)
+    text = config_file.read_text(encoding="utf-8") if config_file.is_file() else ""
+    before = _read_toml(config_file)
+    existing = _existing_codex_entry(before, config_file)
+
+    if existing is not None and not _strip_toml_tables(text, _CODEX_TABLE)[1]:
+        # The entry is there but not as a table header — an inline table or a
+        # dotted key. Appending ours would be a duplicate definition, which
+        # makes the whole file unreadable to Codex; removing it means editing
+        # a line we cannot see the shape of.
+        raise SlopWriterError(
+            f"{config_file} defines `mcp_servers.{SERVER_NAME}` in a form this "
+            "command cannot rewrite.",
+            hint="Delete that entry by hand — as an inline table or a dotted "
+            "key it cannot be replaced in place — then run `slop-writer "
+            "install` again.",
+        )
+    return config_file, text, before, existing
+
+
+def _install_codex(project_root: Path) -> ClientInstall:
+    """Codex's one file, holding both halves of the wiring.
+
+    The two idempotency policies meet inside it: the server entry is rewritten
+    every run because that rewrite is the upgrade path, and the three approval
+    tables are seeded on first install only because Codex itself writes into
+    them when a human answers "don't ask me again"."""
+    config_file, text, before, existing = _codex_state(project_root)
+    first_install = existing is None
+
+    section: dict = dict(codex_server_entry())
+    # On an upgrade the gate is whatever the human left there, including
+    # nothing: a table they deleted stays deleted, and a mode they changed
+    # stays changed.
+    tools = codex_approval_rules() if first_install else (existing or {}).get("tools")
+    if isinstance(tools, dict) and tools:
+        section["tools"] = tools
+
+    new_text = _rewritten_codex_config(config_file, text, before, section)
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text(new_text, encoding="utf-8")
+
+    return ClientInstall(
+        client=CODEX,
+        first_install=first_install,
+        config_file=config_file,
+        gate_file=config_file,
+        gate_seeded=first_install,
+        gate_tools=CODEX_PUBLISH_TOOLS,
+    )
+
+
+_INSTALLERS = {CLAUDE: _install_claude, CODEX: _install_codex}
+#: Read-and-refuse, one per client. Same keys as `_INSTALLERS` by construction
+#: of the loop below — a client with no state function raises `KeyError` before
+#: anything is written rather than skipping its refusals.
+_STATES = {CLAUDE: _claude_state, CODEX: _codex_state}
+
+
+def install_project(
+    project_root: Path, clients: Sequence[str] | None = None
+) -> InstallResult:
+    """Wire this project's client configuration to the MCP server.
+
+    `clients` defaults to Claude Code alone, so a bare `install` writes exactly
+    what it wrote before Codex existed. Cursor and the Copilot coding agent are
+    still not written: their launch cwd is unverified and this design rests on
+    cwd being the project root, so shipping the untested half means fielding
+    the bug reports for it. `render.summarize_install` prints what those users
+    should paste instead."""
+    selected = normalize_clients(clients, DEFAULT_CLIENTS)
+    # Every refusal first, so wiring two clients cannot write one and then stop
+    # on the other's machine-wide policy — the human would be left holding a
+    # failure and no report of what did land.
+    for name in selected:
+        _STATES[name](project_root)
+    installed = tuple(_INSTALLERS[name](project_root) for name in selected)
+
+    # Written whichever clients were named: these two belong to no client, and
+    # an agent nobody installed still needs a way in.
+    agents_file = project_root / AGENTS_FILE
+    agents_written = _write_address_block(
+        agents_file, "/".join((*AGENTS_SKILLS_PARENT, SKILL_DIR_NAME))
+    )
+    shared_skill = project_root / Path(*AGENTS_SKILLS_PARENT) / SKILL_DIR_NAME
+    shared_existed = shared_skill.exists()
+    _copy_skill(shared_skill)
+
     return InstallResult(
         project_root=project_root,
         version=package_version(),
-        first_install=first_install,
-        mcp_config=mcp_config,
-        skill_target=skill_target,
-        settings=settings,
-        memory_file=memory_file,
-        permissions_seeded=first_install,
-        memory_block_written=first_install,
-        skill_existed=skill_existed,
-        legacy_skill_removed=legacy_skill_removed,
+        clients=installed,
+        agents_file=agents_file,
+        agents_block_written=agents_written,
+        shared_skill_target=shared_skill,
+        shared_skill_existed=shared_existed,
         skills_lock_names=_skills_lock_names(project_root),
         # The one self-check worth running: a `uv tool install` that missed
         # PATH surfaces inside the client as an undiagnosable "server didn't
@@ -401,14 +920,13 @@ def install_project(project_root: Path) -> InstallResult:
     )
 
 
-def uninstall_project(project_root: Path) -> UninstallResult:
-    """Remove exactly what `install` wrote, and nothing else.
+# --------------------------------------------------------------------------
+# Per-client uninstall
+# --------------------------------------------------------------------------
 
-    `.tg-analytic/` is never touched: it holds a live Telegram session and
-    per-channel databases that took hours of scraping to build. Permission
-    entries are left too — they are the human's file, and an `ask` rule that
-    outlives the server it guarded costs nothing."""
-    result = UninstallResult(project_root=project_root)
+
+def _uninstall_claude(project_root: Path) -> ClientUninstall:
+    result = ClientUninstall(client=CLAUDE)
 
     mcp_config = project_root / MCP_CONFIG_NAME
     config = _read_json(mcp_config)
@@ -423,8 +941,73 @@ def uninstall_project(project_root: Path) -> UninstallResult:
         shutil.rmtree(skill_target)
         result.removed.append(str(skill_target.relative_to(project_root)))
 
-    if _strip_memory_block(project_root / MEMORY_FILE):
+    if _strip_address_block(project_root / MEMORY_FILE):
         result.removed.append(f"{MEMORY_FILE} address block")
+    return result
+
+
+def _uninstall_codex(project_root: Path) -> ClientUninstall:
+    result = ClientUninstall(client=CODEX)
+
+    config_file = project_root / Path(*CODEX_CONFIG_PATH)
+    if not config_file.is_file():
+        return result
+    text = config_file.read_text(encoding="utf-8")
+    if not _strip_toml_tables(text, _CODEX_TABLE)[1]:
+        return result
+    # Parsed for the same reason `install` parses: a file this command cannot
+    # read is a file it must not edit, and this one can hold every other MCP
+    # server the human registered.
+    new_text = _rewritten_codex_config(
+        config_file, text, _read_toml(config_file), None
+    )
+    if new_text.strip():
+        config_file.write_text(new_text, encoding="utf-8")
+    else:
+        # Nothing of the human's left in it — and if `.codex/` now holds
+        # nothing either, it was ours to create and ours to take away.
+        config_file.unlink()
+        if not any(config_file.parent.iterdir()):
+            config_file.parent.rmdir()
+    result.removed.append(
+        f"{'/'.join(CODEX_CONFIG_PATH)} entry `mcp_servers.{SERVER_NAME}`"
+    )
+    return result
+
+
+_UNINSTALLERS = {CLAUDE: _uninstall_claude, CODEX: _uninstall_codex}
+
+
+def uninstall_project(
+    project_root: Path, clients: Sequence[str] | None = None
+) -> UninstallResult:
+    """Remove exactly what `install` wrote, and nothing else.
+
+    With no selection this removes **every** client's wiring — safe in a way
+    the install default is not, because uninstall only ever removes its own
+    markers. Narrowed to one client it leaves the others alone, so dropping a
+    client is not an all-or-nothing act.
+
+    `.tg-analytic/` is never touched, whatever the selection: it holds a live
+    Telegram session and per-channel databases that took hours of scraping to
+    build. Permission entries are left too — they are the human's file, and an
+    `ask` rule that outlives the server it guarded costs nothing."""
+    selected = normalize_clients(clients, CLIENTS)
+    result = UninstallResult(
+        project_root=project_root,
+        clients=tuple(_UNINSTALLERS[name](project_root) for name in selected),
+    )
+
+    # The cross-agent pair belongs to no client, so only a selection covering
+    # all of them can take it: with Claude Code dropped and Codex kept, the
+    # skill `.agents/skills/` holds is still the one Codex reads.
+    if set(selected) == set(CLIENTS):
+        shared_skill = project_root / Path(*AGENTS_SKILLS_PARENT) / SKILL_DIR_NAME
+        if shared_skill.is_dir():
+            shutil.rmtree(shared_skill)
+            result.shared_removed.append(str(shared_skill.relative_to(project_root)))
+        if _strip_address_block(project_root / AGENTS_FILE):
+            result.shared_removed.append(f"{AGENTS_FILE} address block")
 
     if (project_root / DATA_DIR_NAME).exists():
         result.kept.append(f"{DATA_DIR_NAME}/ (session, databases, media)")
@@ -435,8 +1018,8 @@ def uninstall_project(project_root: Path) -> UninstallResult:
 
 
 def other_client_entry() -> str:
-    """The JSON a Cursor / Codex / Copilot user pastes by hand.
+    """The JSON a Cursor / Copilot user pastes by hand.
 
-    Printed rather than written, with its provenance attached: this project has
-    verified the cwd assumption on Claude Code alone."""
+    Printed rather than written, with its provenance attached: those two
+    clients' launch cwd is unverified, and this design rests on it."""
     return json.dumps({"mcpServers": {SERVER_NAME: server_entry()}}, indent=2)

--- a/src/slop_writer/render.py
+++ b/src/slop_writer/render.py
@@ -623,30 +623,18 @@ def summarize_install(result) -> str:
     from .install import SERVER_NAME, other_client_entry
 
     root = result.project_root
-    out = [f"Wired {SERVER_NAME} {result.version} into {root}", ""]
-    out.append(f"  {result.mcp_config.relative_to(root)} — server entry "
-               f"(overwritten every install; that is the upgrade path)")
-    skill_rel = result.skill_target.relative_to(root)
-    out.append(f"  {skill_rel} — skill, "
-               f"{'replaced' if result.skill_existed else 'installed'}")
-    if result.legacy_skill_removed is not None:
-        # Deleting something the user did not ask us to delete is exactly the
-        # kind of thing that must not be silent (#34).
-        out.append(f"  {result.legacy_skill_removed.relative_to(root)} — "
-                   f"removed: this skill's pre-0.4 directory, which would "
-                   f"otherwise load alongside the current one")
-    if result.permissions_seeded:
-        out.append(f"  {result.settings.relative_to(root)} — permissions: "
-                   f"reads allowed, publishing behind a prompt")
-        out.append(f"  {result.memory_file.relative_to(root)} — address block "
-                   f"so subagents find the skill")
-    else:
-        # Seeding on every run would silently restore an `ask` rule the human
-        # deliberately removed — headless autoposting is a supported choice.
-        out.append("  (permissions and CLAUDE.md left alone — seeded on first "
-                   "install only, so your edits survive an upgrade)")
-        out.append("  publishing tools this version expects under `ask`: "
-                   + ", ".join(result.ask_tools))
+    out = [f"Wired {SERVER_NAME} {result.version} into {root}"]
+    for client in result.clients:
+        out.append("")
+        out.extend(_install_section(client, root))
+
+    out.append("")
+    out.append("Every agent, whichever client you wired:")
+    out.append(f"  {result.agents_file.relative_to(root)} — address block so an "
+               f"agent with no skills listing can find the skill"
+               + ("" if result.agents_block_written else " (already there)"))
+    out.append(f"  {result.shared_skill_target.relative_to(root)} — skill, "
+               f"{'replaced' if result.shared_skill_existed else 'installed'}")
 
     if result.skills_lock_names:
         from .install import LEGACY_SKILL_DIR_NAME
@@ -672,23 +660,78 @@ def summarize_install(result) -> str:
                    "`which slop-writer`.")
 
     out.append("")
-    out.append("Verified on Claude Code only. For Cursor, Codex or the Copilot "
-               "coding agent, paste this into their MCP config yourself:")
+    out.append("Cursor and the Copilot coding agent are not written for: their "
+               "launch directory is unverified, so paste this into their MCP "
+               "config yourself.")
     out.append("")
     out.append(other_client_entry())
     out.append("")
-    out.append("Next: restart your MCP client (.mcp.json is read at session "
-               "start only), and run `slop-writer init` to log in to Telegram.")
+    out.append("Next: restart your MCP client (project configuration is read at "
+               "session start only), and run `slop-writer init` to log in to "
+               "Telegram.")
     return "\n".join(out)
+
+
+def _install_section(client, root) -> list[str]:
+    """One client's half of the project, named as that client's own files.
+
+    A section per client rather than one merged list: first install, the
+    artifacts and the "already existed" facts differ per client, so a merged
+    report would say something true of neither."""
+    from .install import CODEX
+
+    state = "first install" if client.first_install else "already wired, upgraded"
+    out = [f"{client.client} — {state}"]
+    out.append(f"  {client.config_file.relative_to(root)} — server entry "
+               f"(overwritten every install; that is the upgrade path)")
+    if client.skill_target is not None:
+        out.append(f"  {client.skill_target.relative_to(root)} — skill, "
+                   f"{'replaced' if client.skill_existed else 'installed'}")
+    if client.legacy_skill_removed is not None:
+        # Deleting something the user did not ask us to delete is exactly the
+        # kind of thing that must not be silent (#34).
+        out.append(f"  {client.legacy_skill_removed.relative_to(root)} — "
+                   f"removed: this skill's pre-0.4 directory, which would "
+                   f"otherwise load alongside the current one")
+    if client.gate_seeded:
+        out.append(f"  {client.gate_file.relative_to(root)} — approval gate: "
+                   f"reads allowed, publishing behind a prompt")
+        if client.address_block_written and client.address_file is not None:
+            out.append(f"  {client.address_file.relative_to(root)} — address "
+                       f"block so subagents find the skill")
+    else:
+        # Seeding on every run would silently restore a rule the human
+        # deliberately removed — headless autoposting is a supported choice.
+        out.append(f"  (the gate in {client.gate_file.relative_to(root)} left "
+                   f"alone — seeded on first install only, so your edits "
+                   f"survive an upgrade)")
+        out.append("  publishing tools this version expects behind a prompt: "
+                   + ", ".join(client.gate_tools))
+    if client.client == CODEX:
+        # Silent by policy rather than by fault is the one failure a user
+        # cannot diagnose from anything this command writes.
+        out.append("  ! Codex ignores a project's configuration until you "
+                   "trust the directory, and that trust lives in your own "
+                   "global config — so a fresh clone stays silent until you "
+                   "answer Codex's trust prompt in this directory.")
+    return out
 
 
 def summarize_uninstall(result) -> str:
     """What `uninstall` removed, and — more usefully — what it did not."""
-    out = [f"Removed slop-writer's wiring from {result.project_root}", ""]
-    if result.removed:
-        out.extend(f"  {item}" for item in result.removed)
-    else:
-        out.append("  (nothing to remove — was it installed in this project?)")
+    out = [f"Removed slop-writer's wiring from {result.project_root}"]
+    for client in result.clients:
+        out.append("")
+        out.append(f"{client.client}:")
+        if client.removed:
+            out.extend(f"  {item}" for item in client.removed)
+        else:
+            out.append("  (nothing to remove — was it installed for this "
+                       "client?)")
+    if result.shared_removed:
+        out.append("")
+        out.append("Every agent:")
+        out.extend(f"  {item}" for item in result.shared_removed)
     if result.kept:
         out.append("")
         out.append("Kept:")

--- a/src/slop_writer/server.py
+++ b/src/slop_writer/server.py
@@ -105,6 +105,26 @@ def permission_rules() -> dict[str, list[str]]:
         "ask": [f"mcp__{SERVER_NAME}__{name}" for name in WRITE_TOOLS],
     }
 
+
+def codex_approval_rules() -> dict[str, dict[str, str]]:
+    """The same gate in Codex's vocabulary: the `tools` tables `install`
+    writes under `[mcp_servers.slop-writer]` in `.codex/config.toml`.
+
+    A sibling of `permission_rules` rather than a translation living in
+    `install.py`, for the reason that put the first one here: the gate and the
+    roster are one fact, and a second module is a second place to forget. The
+    two emitters spell the same three names differently — Claude Code matches
+    `mcp__slop-writer__publish_edit`, Codex matches the bare `publish_edit`
+    under its own server — and `tests/test_server.py` compares both against the
+    roster and against each other (adr/0008).
+
+    `prompt` is the only value that fits: Codex's `approval_mode` accepts
+    `auto`, `prompt`, `writes` and `approve`, and none of them is a deny. This
+    axis can put a human in front of a Telegram write; it cannot forbid one.
+
+    A returned dict, for the same reason as above."""
+    return {name: {"approval_mode": "prompt"} for name in WRITE_TOOLS}
+
 # The two failures whose remedy is a human at a terminal. The domain's own
 # hints name the CLI's remedy (a setup skill, a script path); the server's
 # remedy is `slop-writer init`, and picking it here rather than parameterising

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,28 +1,44 @@
-"""`slop-writer install` / `uninstall` — the agent wiring (#19, #20).
+"""`slop-writer install` / `uninstall` — the agent wiring (#19, #20, adr/0008).
 
 Every test here runs against a `tmp_path` project. The one thing that cannot
 be faked is which files a real user already has, so each test starts by
 planting the config it is about to defend: another MCP server, a hand-written
 permission list, a CLAUDE.md with the human's own notes.
+
+Two clients now, and the shape of an assertion follows from that: a fact is
+asserted against **one client's** half of the project, because what a project
+holds for one says nothing about another. The three that belong to neither —
+the cross-agent block, the cross-agent skill, `.tg-analytic/` surviving — are
+asserted against the project.
+
+What a client would find on disk is the subject throughout: the TOML emitter
+is read back through the file it wrote, never called directly, exactly as the
+JSON writer is.
 """
 
 import json
+import tomllib
 
 import pytest
 
-from slop_writer.errors import SlopWriterError
+from slop_writer.errors import SlopWriterError, UsageError
 from slop_writer.install import (
     BLOCK_END,
     BLOCK_START,
+    CLAUDE,
+    CLIENTS,
+    CODEX,
+    CODEX_PUBLISH_TOOLS,
     LEGACY_SKILL_DIR_NAME,
     PUBLISH_TOOLS,
     SERVER_NAME,
+    codex_server_entry,
     install_project,
     server_entry,
     skill_source,
     uninstall_project,
 )
-from slop_writer.render import summarize_install
+from slop_writer.render import summarize_install, summarize_uninstall
 
 
 def read(path):
@@ -35,6 +51,115 @@ def mcp_config(root):
 
 def settings(root):
     return read(root / ".claude" / "settings.json")["permissions"]
+
+
+def codex_config(root):
+    return tomllib.loads((root / ".codex" / "config.toml").read_text())
+
+
+def codex_entry(root):
+    return codex_config(root)["mcp_servers"][SERVER_NAME]
+
+
+# --------------------------------------------------------------------------
+# Client selection
+# --------------------------------------------------------------------------
+
+
+def test_a_bare_install_wires_claude_code_and_nothing_else(tmp_path):
+    """User story 3: upgrading changes nothing about what a project that only
+    ever used one client holds."""
+    result = install_project(tmp_path)
+
+    assert [c.client for c in result.clients] == [CLAUDE]
+    assert mcp_config(tmp_path)[SERVER_NAME] == server_entry()
+    assert not (tmp_path / ".codex").exists()
+
+
+def test_naming_claude_is_the_same_as_naming_nothing(tmp_path):
+    explicit = install_project(tmp_path, [CLAUDE])
+
+    assert [c.client for c in explicit.clients] == [CLAUDE]
+    assert mcp_config(tmp_path)[SERVER_NAME] == server_entry()
+
+
+def test_the_selection_is_repeatable_and_deduplicated(tmp_path):
+    result = install_project(tmp_path, [CODEX, CLAUDE, CODEX])
+
+    assert [c.client for c in result.clients] == [CODEX, CLAUDE]
+    assert SERVER_NAME in mcp_config(tmp_path)
+    assert SERVER_NAME in codex_config(tmp_path)["mcp_servers"]
+
+
+def test_an_unknown_client_is_a_usage_error(tmp_path):
+    """Named and not written is worse than refused: the human would believe
+    the project is wired for something it is not."""
+    with pytest.raises(UsageError):
+        install_project(tmp_path, ["emacs"])
+    with pytest.raises(UsageError):
+        uninstall_project(tmp_path, ["emacs"])
+
+
+def test_first_install_is_a_property_of_a_client(tmp_path):
+    """A project can be an upgrade for one client and a first install for
+    another, which is why the flag hangs off the client and not the result."""
+    install_project(tmp_path, [CLAUDE])
+
+    second = install_project(tmp_path, [CLAUDE, CODEX])
+
+    assert not second.for_client(CLAUDE).first_install
+    assert second.for_client(CODEX).first_install
+
+
+def test_first_install_is_detected_from_the_clients_own_entry_alone(tmp_path):
+    """No marker file, on either side: the absence of our key in that client's
+    config is the signal, so there is no second piece of state to drift out of
+    sync (#19)."""
+    for client in (CLAUDE, CODEX):
+        assert install_project(tmp_path, [client]).for_client(client).first_install
+        assert not install_project(tmp_path, [client]).for_client(client).first_install
+
+
+@pytest.mark.parametrize("client", CLIENTS)
+def test_every_known_client_can_be_wired_and_unwired(tmp_path, client):
+    """The roster and the two per-client tables are one fact — a name accepted
+    at the command line with no installer behind it would fail at the moment a
+    user typed it."""
+    assert install_project(tmp_path, [client]).for_client(client) is not None
+
+    result = uninstall_project(tmp_path, [client])
+
+    assert result.for_client(client).removed
+
+
+def test_a_refusal_for_one_client_writes_nothing_for_any(tmp_path, monkeypatch):
+    """Wiring two clients is one command, so it either reports what landed or
+    lands nothing. Writing Claude Code and *then* refusing Codex leaves the
+    human with a failure and no report of the half that succeeded."""
+    policy = tmp_path / "managed_config.toml"
+    policy.write_text("")
+    monkeypatch.setattr("slop_writer.install.MANAGED_CODEX_PATHS", (str(policy),))
+
+    with pytest.raises(SlopWriterError):
+        install_project(tmp_path, [CLAUDE, CODEX])
+
+    assert not (tmp_path / ".mcp.json").exists()
+    assert not (tmp_path / "AGENTS.md").exists()
+
+
+def test_installing_one_client_leaves_the_others_half_untouched(tmp_path):
+    """The independence the glossary's **Client** entry claims."""
+    install_project(tmp_path, [CLAUDE])
+    before = (tmp_path / ".mcp.json").read_text()
+
+    install_project(tmp_path, [CODEX])
+
+    assert (tmp_path / ".mcp.json").read_text() == before
+
+
+# --------------------------------------------------------------------------
+# Claude Code
+# --------------------------------------------------------------------------
 
 
 def test_the_server_entry_carries_no_machine_specific_string():
@@ -70,7 +195,7 @@ def test_install_seeds_the_read_write_split(tmp_path):
     perms = settings(tmp_path)
     assert f"mcp__{SERVER_NAME}" in perms["allow"]
     assert list(PUBLISH_TOOLS) == perms["ask"]
-    assert result.permissions_seeded
+    assert result.for_client(CLAUDE).gate_seeded
 
 
 def test_the_permission_block_is_the_servers_own(tmp_path):
@@ -110,8 +235,8 @@ def test_a_reinstall_does_not_restore_a_removed_ask_rule(tmp_path):
 
     result = install_project(tmp_path)
 
-    assert not result.first_install
-    assert not result.permissions_seeded
+    assert not result.for_client(CLAUDE).first_install
+    assert not result.for_client(CLAUDE).gate_seeded
     assert PUBLISH_TOOLS[0] not in settings(tmp_path)["ask"]
 
 
@@ -129,19 +254,12 @@ def test_the_server_entry_is_replaced_on_every_run(tmp_path):
     assert mcp_config(tmp_path)[SERVER_NAME] == server_entry()
 
 
-def test_first_install_is_detected_from_the_mcp_entry_alone(tmp_path):
-    """No marker file: the absence of our key in `.mcp.json` is the signal, so
-    there is no second piece of state to drift out of sync (#19)."""
-    assert install_project(tmp_path).first_install
-    assert not install_project(tmp_path).first_install
-
-
 def test_install_writes_the_skill_and_replaces_it_next_time(tmp_path):
     result = install_project(tmp_path)
     skill = tmp_path / ".claude" / "skills" / "slop-writer"
 
     assert (skill / "SKILL.md").is_file()
-    assert not result.skill_existed
+    assert not result.for_client(CLAUDE).skill_existed
 
     # The skill is documentation of the server you have, never the user's
     # config — a local edit is not preserved, and `install` says so (#19).
@@ -149,7 +267,7 @@ def test_install_writes_the_skill_and_replaces_it_next_time(tmp_path):
     (skill / "stray.md").write_text("left over from an older version")
     again = install_project(tmp_path)
 
-    assert again.skill_existed
+    assert again.for_client(CLAUDE).skill_existed
     assert (skill / "SKILL.md").read_text() != "mine now"
     assert not (skill / "stray.md").exists()
 
@@ -173,7 +291,7 @@ def test_install_removes_the_pre_04_skill_directory(tmp_path):
     result = install_project(tmp_path)
 
     assert not legacy.exists()
-    assert result.legacy_skill_removed == legacy
+    assert result.for_client(CLAUDE).legacy_skill_removed == legacy
     assert (tmp_path / ".claude" / "skills" / "slop-writer" / "SKILL.md").is_file()
 
 
@@ -193,8 +311,299 @@ def test_a_project_without_the_old_skill_reports_no_removal(tmp_path):
     install stops being read."""
     result = install_project(tmp_path)
 
-    assert result.legacy_skill_removed is None
+    assert result.for_client(CLAUDE).legacy_skill_removed is None
     assert LEGACY_SKILL_DIR_NAME not in summarize_install(result)
+
+
+def test_install_refuses_to_guess_at_corrupt_json(tmp_path):
+    """Starting from `{}` would drop every other server in the file."""
+    (tmp_path / ".mcp.json").write_text("{ not json")
+
+    with pytest.raises(SlopWriterError) as e:
+        install_project(tmp_path)
+    assert "not valid JSON" in e.value.message
+
+
+def test_install_stops_when_mcp_config_is_enterprise_managed(tmp_path, monkeypatch):
+    """#11: a `managed-mcp.json` takes exclusive control and `add` fails
+    outright. Report, never retry."""
+    policy = tmp_path / "managed-mcp.json"
+    policy.write_text("{}")
+    monkeypatch.setattr("slop_writer.install.MANAGED_MCP_PATHS", (str(policy),))
+
+    with pytest.raises(SlopWriterError) as e:
+        install_project(tmp_path)
+    assert "managed" in e.value.message
+    assert str(policy) in e.value.message
+
+
+def test_a_managed_claude_policy_does_not_stop_the_other_client(tmp_path, monkeypatch):
+    """Independence again: one client's machine-wide policy says nothing about
+    what the other can be wired for."""
+    policy = tmp_path / "managed-mcp.json"
+    policy.write_text("{}")
+    monkeypatch.setattr("slop_writer.install.MANAGED_MCP_PATHS", (str(policy),))
+
+    assert install_project(tmp_path, [CODEX]).for_client(CODEX).first_install
+
+
+# --------------------------------------------------------------------------
+# Codex
+# --------------------------------------------------------------------------
+
+
+def test_the_codex_entry_carries_no_machine_specific_string():
+    """The property the Claude Code entry has, held to for the second client:
+    a committed entry a teammate clones and uses unchanged. If a live run ever
+    shows Codex launching the server somewhere other than the project root,
+    this is the assertion that has to be changed on purpose."""
+    entry = codex_server_entry()
+    assert entry["args"] == ["serve", "--mcp"]
+    assert not any("/" in arg or "\\" in arg for arg in entry["args"])
+    assert "cwd" not in entry
+    assert "--project" not in entry["args"]
+
+
+def test_install_writes_the_codex_server_entry(tmp_path):
+    install_project(tmp_path, [CODEX])
+
+    assert codex_entry(tmp_path)["command"] == "slop-writer"
+    assert codex_entry(tmp_path)["args"] == ["serve", "--mcp"]
+
+
+def test_the_codex_approval_tables_name_exactly_the_publishing_tools(tmp_path):
+    """The gate the distribution carries, on the second client. Compared
+    against the roster's own emitter rather than a literal list — that is what
+    makes a tool renamed without its rule fail here (adr/0008)."""
+    install_project(tmp_path, [CODEX])
+
+    tools = codex_entry(tmp_path)["tools"]
+    assert set(tools) == set(CODEX_PUBLISH_TOOLS)
+    assert all(table == {"approval_mode": "prompt"} for table in tools.values())
+
+
+def test_the_codex_gate_is_seeded_on_first_install_only(tmp_path):
+    """"Allow and don't ask me again" is a decision Codex records in this very
+    file. An upgrade that restored the prompt would overrule a human."""
+    install_project(tmp_path, [CODEX])
+    path = tmp_path / ".codex" / "config.toml"
+    path.write_text(
+        path.read_text().replace('approval_mode = "prompt"', 'approval_mode = "auto"', 1)
+    )
+
+    result = install_project(tmp_path, [CODEX])
+
+    assert not result.for_client(CODEX).gate_seeded
+    modes = [t["approval_mode"] for t in codex_entry(tmp_path)["tools"].values()]
+    assert "auto" in modes
+
+
+def test_a_deleted_codex_approval_table_stays_deleted(tmp_path):
+    install_project(tmp_path, [CODEX])
+    path = tmp_path / ".codex" / "config.toml"
+    dropped = CODEX_PUBLISH_TOOLS[0]
+    path.write_text(
+        "\n".join(
+            line
+            for line in path.read_text().splitlines()
+            if dropped not in line
+        )
+    )
+
+    install_project(tmp_path, [CODEX])
+
+    assert dropped not in codex_entry(tmp_path).get("tools", {})
+
+
+def test_the_codex_server_entry_is_rewritten_on_every_run(tmp_path):
+    """The upgrade path, on the half of the file that is ours."""
+    install_project(tmp_path, [CODEX])
+    path = tmp_path / ".codex" / "config.toml"
+    path.write_text(path.read_text().replace('"--mcp"', '"--legacy"'))
+
+    install_project(tmp_path, [CODEX])
+
+    assert codex_entry(tmp_path)["args"] == ["serve", "--mcp"]
+
+
+def test_install_merges_into_an_existing_codex_config(tmp_path):
+    """Other servers and the user's own keys survive, and so does the text
+    they wrote around them — the file is rewritten only where it is ours."""
+    path = tmp_path / ".codex" / "config.toml"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        '# my notes\nmodel = "gpt-5"\n\n'
+        "[mcp_servers.other]\n"
+        'command = "other-server"\n'
+        'args = ["--stdio"]\n'
+    )
+
+    install_project(tmp_path, [CODEX])
+
+    config = codex_config(tmp_path)
+    assert config["model"] == "gpt-5"
+    assert config["mcp_servers"]["other"] == {
+        "command": "other-server",
+        "args": ["--stdio"],
+    }
+    assert "# my notes" in path.read_text()
+
+
+def test_reinstalling_does_not_duplicate_the_codex_section(tmp_path):
+    install_project(tmp_path, [CODEX])
+    install_project(tmp_path, [CODEX])
+
+    text = (tmp_path / ".codex" / "config.toml").read_text()
+    assert text.count(f"[mcp_servers.{SERVER_NAME}]") == 1
+    assert text.count("approval_mode") == len(CODEX_PUBLISH_TOOLS)
+
+
+def test_install_refuses_to_guess_at_corrupt_toml(tmp_path):
+    """Same reason as the JSON side: this file can hold every other MCP server
+    the human registered, and overwriting it is not undoable from a message."""
+    path = tmp_path / ".codex" / "config.toml"
+    path.parent.mkdir(parents=True)
+    path.write_text("[mcp_servers\nbroken = ")
+    before = path.read_text()
+
+    with pytest.raises(SlopWriterError) as e:
+        install_project(tmp_path, [CODEX])
+
+    assert "not valid TOML" in e.value.message
+    assert path.read_text() == before
+
+
+def test_install_refuses_an_entry_it_cannot_rewrite_in_place(tmp_path):
+    """An inline table cannot be replaced by appending a `[table]` header —
+    that is a duplicate definition, and Codex would refuse the whole file."""
+    path = tmp_path / ".codex" / "config.toml"
+    path.parent.mkdir(parents=True)
+    path.write_text(f'[mcp_servers]\n"{SERVER_NAME}" = {{ command = "old" }}\n')
+
+    with pytest.raises(SlopWriterError) as e:
+        install_project(tmp_path, [CODEX])
+    assert "cannot rewrite" in e.value.message
+
+
+def test_install_proves_the_rewrite_before_it_writes(tmp_path):
+    """Our tables are found by reading `[header]` lines out of the text, and a
+    header-shaped line inside a multi-line string is the one case that fools
+    it. Deleting something the human wrote is silent and unrecoverable, so the
+    result is re-parsed and compared before anything reaches disk."""
+    path = tmp_path / ".codex" / "config.toml"
+    path.parent.mkdir(parents=True)
+    before = 'notes = """\n[mcp_servers.slop-writer]\nnot a table at all\n"""\n'
+    path.write_text(before)
+
+    with pytest.raises(SlopWriterError) as e:
+        install_project(tmp_path, [CODEX])
+
+    assert path.read_text() == before
+    assert "Nothing was written" in e.value.hint
+
+
+def test_install_stops_when_codex_config_is_managed(tmp_path, monkeypatch):
+    """A managed layer outranks the project layer, so the gate written here
+    could be overridden without notice."""
+    policy = tmp_path / "managed_config.toml"
+    policy.write_text("")
+    monkeypatch.setattr("slop_writer.install.MANAGED_CODEX_PATHS", (str(policy),))
+
+    with pytest.raises(SlopWriterError) as e:
+        install_project(tmp_path, [CODEX])
+    assert "managed" in e.value.message
+    assert str(policy) in e.value.message
+
+
+def test_the_global_codex_config_is_never_written(tmp_path, monkeypatch):
+    """It is the human's file by the same rule that makes the permission block
+    theirs, and on a real machine it holds other servers' bearer tokens."""
+    home = tmp_path / "home"
+    (home / ".codex").mkdir(parents=True)
+    global_config = home / ".codex" / "config.toml"
+    global_config.write_text('model = "gpt-5"\n')
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    install_project(tmp_path / "project", [CODEX])
+
+    assert global_config.read_text() == 'model = "gpt-5"\n'
+
+
+def test_the_codex_report_states_the_trust_requirement(tmp_path):
+    """Silent by policy rather than by fault is the one failure the human
+    cannot diagnose from anything this command wrote."""
+    printed = summarize_install(install_project(tmp_path, [CODEX]))
+
+    assert "trust" in printed
+
+
+# --------------------------------------------------------------------------
+# The cross-agent pair — owned by no client
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("clients", [[CLAUDE], [CODEX], [CLAUDE, CODEX]])
+def test_the_cross_agent_pair_is_written_whichever_client_was_named(tmp_path, clients):
+    """An agent nobody installed can still find the skill — which is the whole
+    reason these two belong to no client."""
+    install_project(tmp_path, clients)
+
+    assert BLOCK_START in (tmp_path / "AGENTS.md").read_text()
+    assert (tmp_path / ".agents" / "skills" / "slop-writer" / "SKILL.md").is_file()
+
+
+def test_the_cross_agent_block_addresses_the_copy_its_readers_can_open(tmp_path):
+    """Each file names the skill directory *its own* readers reach: `CLAUDE.md`
+    the one under `.claude/`, `AGENTS.md` the one under `.agents/`."""
+    install_project(tmp_path)
+
+    assert ".agents/skills/slop-writer/SKILL.md" in (tmp_path / "AGENTS.md").read_text()
+    assert ".claude/skills/slop-writer/SKILL.md" in (tmp_path / "CLAUDE.md").read_text()
+
+
+@pytest.mark.parametrize("memory", ["CLAUDE.md", "AGENTS.md"])
+def test_an_address_block_is_an_address_and_not_an_invariant(tmp_path, memory):
+    """#26 measured who needs this: a custom subagent with a restricted
+    `tools:` list, which has no skills listing and no `Skill` tool — so the
+    block must name a file path. And no invariant is copied in: one fact in
+    memory reads as "the knowledge is here" and stops the fetch. `AGENTS.md`
+    is stricter still — it is injected into every turn under a size cap."""
+    install_project(tmp_path)
+    block = (tmp_path / memory).read_text()
+
+    assert f"mcp__{SERVER_NAME}__*" in block
+    for invariant in ("MAX(id)", "is_thread_root", "post_metrics", "SELECT"):
+        assert invariant not in block
+
+
+@pytest.mark.parametrize("memory", ["CLAUDE.md", "AGENTS.md"])
+def test_an_address_block_keeps_the_text_around_it(tmp_path, memory):
+    """Whether the human's text precedes the block or follows it."""
+    (tmp_path / memory).write_text("# My project\n\nSome notes.\n")
+
+    install_project(tmp_path)
+    (tmp_path / memory).write_text(
+        (tmp_path / memory).read_text() + "\nmy own note\n"
+    )
+    install_project(tmp_path)
+    text = (tmp_path / memory).read_text()
+
+    assert text.startswith("# My project\n\nSome notes.\n")
+    assert "my own note" in text
+    assert text.count(BLOCK_START) == 1
+
+
+def test_the_cross_agent_skill_is_replaced_wholesale(tmp_path):
+    result = install_project(tmp_path)
+    skill = tmp_path / ".agents" / "skills" / "slop-writer"
+    assert not result.shared_skill_existed
+
+    (skill / "stray.md").write_text("left over from an older version")
+    again = install_project(tmp_path)
+
+    assert again.shared_skill_existed
+    assert not (skill / "stray.md").exists()
 
 
 def test_the_old_name_in_skills_lock_is_reported_and_not_edited(tmp_path):
@@ -226,6 +635,20 @@ def test_a_lock_tracking_only_the_current_name_is_the_expected_overlap(tmp_path)
     assert "Remove it yourself" not in printed
 
 
+def test_the_cross_agent_lock_is_read_and_never_edited(tmp_path):
+    """The same boundary, one directory over: another tool's state file with
+    its own hashing scheme."""
+    lock = tmp_path / ".agents" / "skills-lock.json"
+    lock.parent.mkdir(parents=True)
+    before = json.dumps({"skills": {"slop-writer": {"computedHash": "x"}}})
+    lock.write_text(before)
+
+    result = install_project(tmp_path)
+
+    assert "slop-writer" in result.skills_lock_names
+    assert lock.read_text() == before
+
+
 def test_the_shipped_skill_is_the_one_in_this_checkout():
     """Both install channels serve the same directory (#21). If the wheel and
     `npx skills add` disagreed about *which* directory, a project would end up
@@ -234,50 +657,40 @@ def test_the_shipped_skill_is_the_one_in_this_checkout():
     assert (skill_source() / "SKILL.md").is_file()
 
 
-def test_the_address_block_is_an_address_and_not_an_invariant(tmp_path):
-    """#26 measured who needs this: a custom subagent with a restricted
-    `tools:` list, which has no skills listing and no `Skill` tool — so the
-    block must name a file path. And no invariant is copied in: one fact in
-    memory reads as "the knowledge is here" and stops the fetch."""
-    install_project(tmp_path)
-    block = (tmp_path / "CLAUDE.md").read_text()
-
-    assert ".claude/skills/slop-writer/SKILL.md" in block
-    assert f"mcp__{SERVER_NAME}__*" in block
-    for invariant in ("MAX(id)", "is_thread_root", "post_metrics", "SELECT"):
-        assert invariant not in block
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
 
 
-def test_the_address_block_appends_to_an_existing_memory_file(tmp_path):
-    (tmp_path / "CLAUDE.md").write_text("# My project\n\nSome notes.\n")
+def test_the_report_prints_a_section_per_client_with_one_shared_tail(tmp_path):
+    """User story 14: which artifact landed for which client, rather than one
+    merged list. The PATH warning and the next steps are the project's, not a
+    client's, so they are printed once."""
+    printed = summarize_install(install_project(tmp_path, [CLAUDE, CODEX]))
 
-    install_project(tmp_path)
-    text = (tmp_path / "CLAUDE.md").read_text()
-
-    assert text.startswith("# My project\n\nSome notes.\n")
-    assert text.count(BLOCK_START) == 1
-
-
-def test_the_address_block_is_written_once(tmp_path):
-    install_project(tmp_path)
-    (tmp_path / "CLAUDE.md").write_text(
-        (tmp_path / "CLAUDE.md").read_text() + "\nmy own note\n"
-    )
-
-    install_project(tmp_path)
-    text = (tmp_path / "CLAUDE.md").read_text()
-
-    assert text.count(BLOCK_START) == 1
-    assert "my own note" in text
+    assert printed.count(".mcp.json") == 1
+    assert f"{CLAUDE} —" in printed and f"{CODEX} —" in printed
+    assert printed.count("Next: restart") == 1
 
 
-def test_install_refuses_to_guess_at_corrupt_json(tmp_path):
-    """Starting from `{}` would drop every other server in the file."""
-    (tmp_path / ".mcp.json").write_text("{ not json")
+def test_the_report_says_first_install_for_one_client_and_not_the_other(tmp_path):
+    """User story 15: the report matches what each client actually holds."""
+    install_project(tmp_path, [CLAUDE])
 
-    with pytest.raises(SlopWriterError) as e:
-        install_project(tmp_path)
-    assert "not valid JSON" in e.value.message
+    printed = summarize_install(install_project(tmp_path, [CLAUDE, CODEX]))
+
+    assert f"{CLAUDE} — already wired" in printed
+    assert f"{CODEX} — first install" in printed
+
+
+def test_the_report_no_longer_claims_one_verified_client(tmp_path):
+    """The claim adr/0008 made false. What replaces it is the two clients this
+    command does not write, and why."""
+    printed = summarize_install(install_project(tmp_path))
+
+    assert "Verified on Claude Code only" not in printed
+    assert "Cursor" in printed and "unverified" in printed
+    assert "Codex" not in printed.split("Cursor")[1].split("Next:")[0]
 
 
 def test_install_reports_a_missing_command_on_path(tmp_path, monkeypatch):
@@ -285,36 +698,81 @@ def test_install_reports_a_missing_command_on_path(tmp_path, monkeypatch):
     otherwise surfaces inside the client as an undiagnosable "server didn't
     start", which no log the user reads explains."""
     monkeypatch.setattr("slop_writer.install.shutil.which", lambda _: None)
-    assert not install_project(tmp_path).on_path
+    result = install_project(tmp_path, [CLAUDE, CODEX])
+
+    assert not result.on_path
+    assert summarize_install(result).count("not on PATH") == 1
 
 
-def test_install_stops_when_mcp_config_is_enterprise_managed(tmp_path, monkeypatch):
-    """#11: a `managed-mcp.json` takes exclusive control and `add` fails
-    outright. Report, never retry."""
-    policy = tmp_path / "managed-mcp.json"
-    policy.write_text("{}")
-    monkeypatch.setattr("slop_writer.install.MANAGED_MCP_PATHS", (str(policy),))
-
-    with pytest.raises(SlopWriterError) as e:
-        install_project(tmp_path)
-    assert "managed" in e.value.message
+# --------------------------------------------------------------------------
+# Uninstall
+# --------------------------------------------------------------------------
 
 
-def test_uninstall_removes_what_install_wrote(tmp_path):
-    install_project(tmp_path)
+def test_uninstall_removes_what_install_wrote_for_each_client(tmp_path):
+    install_project(tmp_path, [CLAUDE, CODEX])
+
     result = uninstall_project(tmp_path)
 
     assert SERVER_NAME not in mcp_config(tmp_path)
+    assert not (tmp_path / ".codex" / "config.toml").exists()
     assert not (tmp_path / ".claude" / "skills" / "slop-writer").exists()
-    assert BLOCK_START not in (tmp_path / "CLAUDE.md").read_text()
-    assert BLOCK_END not in (tmp_path / "CLAUDE.md").read_text()
-    assert len(result.removed) == 3
+    assert not (tmp_path / ".agents" / "skills" / "slop-writer").exists()
+    for memory in ("CLAUDE.md", "AGENTS.md"):
+        text = (tmp_path / memory).read_text() if (tmp_path / memory).is_file() else ""
+        assert BLOCK_START not in text and BLOCK_END not in text
+    # Per client, because a count over the project would say nothing about
+    # which half of it was undone.
+    assert len(result.for_client(CLAUDE).removed) == 3
+    assert len(result.for_client(CODEX).removed) == 1
+    assert len(result.shared_removed) == 2
+
+
+def test_a_narrowed_uninstall_leaves_the_other_clients_wiring(tmp_path):
+    """Dropping one client is not an all-or-nothing act — and the cross-agent
+    pair stays, because the client that remains still reads it."""
+    install_project(tmp_path, [CLAUDE, CODEX])
+
+    result = uninstall_project(tmp_path, [CODEX])
+
+    assert mcp_config(tmp_path)[SERVER_NAME] == server_entry()
+    assert (tmp_path / ".claude" / "skills" / "slop-writer").is_dir()
+    assert (tmp_path / ".agents" / "skills" / "slop-writer").is_dir()
+    assert BLOCK_START in (tmp_path / "AGENTS.md").read_text()
+    assert not (tmp_path / ".codex" / "config.toml").exists()
+    assert result.for_client(CLAUDE) is None
+    assert result.shared_removed == []
+
+
+def test_naming_every_client_is_not_a_narrowing(tmp_path):
+    """"Unnarrowed" is about what the selection covers, not about how it was
+    typed: with no client left to read them, the cross-agent pair goes too."""
+    install_project(tmp_path, [CLAUDE, CODEX])
+
+    result = uninstall_project(tmp_path, [CODEX, CLAUDE])
+
+    assert not (tmp_path / ".agents" / "skills" / "slop-writer").exists()
+    assert BLOCK_START not in (tmp_path / "AGENTS.md").read_text()
+    assert len(result.shared_removed) == 2
+
+
+def test_uninstall_leaves_the_codex_config_the_user_wrote(tmp_path):
+    """Our section out, everything else byte for byte."""
+    path = tmp_path / ".codex" / "config.toml"
+    path.parent.mkdir(parents=True)
+    before = '# my notes\nmodel = "gpt-5"\n\n[mcp_servers.other]\ncommand = "x"\n'
+    path.write_text(before)
+    install_project(tmp_path, [CODEX])
+
+    uninstall_project(tmp_path, [CODEX])
+
+    assert path.read_text() == before
 
 
 def test_uninstall_never_touches_telegram_state(tmp_path):
     """`.tg-analytic/` holds a live session and databases that took hours of
     scraping to build. Uninstalling the wiring is not a reason to lose them."""
-    install_project(tmp_path)
+    install_project(tmp_path, [CLAUDE, CODEX])
     data = tmp_path / ".tg-analytic"
     data.mkdir()
     (data / "session.session").write_text("credential")
@@ -339,4 +797,8 @@ def test_uninstall_leaves_other_servers_and_the_users_notes(tmp_path):
 
 
 def test_uninstall_on_a_project_that_was_never_installed(tmp_path):
-    assert uninstall_project(tmp_path).removed == []
+    result = uninstall_project(tmp_path)
+
+    assert not any(client.removed for client in result.clients)
+    assert result.shared_removed == []
+    assert "nothing to remove" in summarize_uninstall(result)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -40,6 +40,7 @@ from slop_writer.server import (
     _window,
     assert_text_only,
     build_server,
+    codex_approval_rules,
     normalize_channel,
     permission_rules,
 )
@@ -202,6 +203,45 @@ def test_permission_rules_cannot_be_mutated_between_callers():
     rules = permission_rules()
     rules["ask"].clear()
     assert permission_rules()["ask"]
+
+
+def test_the_codex_approval_tables_name_tools_that_exist(tools):
+    """The second client's gate, held to the first one's standard: a table
+    naming no tool is a gate over nothing."""
+    for name in codex_approval_rules():
+        assert name in tools
+
+
+def test_every_telegram_write_is_gated_in_codex_and_nothing_else_is(tools):
+    """The direction that matters, again: a new `publish_*` tool added without
+    its approval table fails here rather than shipping ungated on one client."""
+    gated = set(codex_approval_rules())
+    assert gated == {name for name in tools if name.startswith("publish_")}
+    assert gated.isdisjoint(READ_TOOLS)
+
+
+def test_the_two_gates_name_the_same_three_tools():
+    """One roster, two client vocabularies. Claude Code matches a prefixed
+    rule name, Codex a bare tool key under its server — and the emitters are
+    two spellings of one fact, which is why they live in this module."""
+    claude = {rule.rsplit("__", 1)[-1] for rule in permission_rules()["ask"]}
+    assert claude == set(codex_approval_rules())
+
+
+def test_the_codex_gate_asks_and_never_forbids(tools):
+    """`approval_mode` has no deny value: this axis can only put a human in
+    front of the call. Pinned so that a future edit to a stronger-sounding
+    mode is a deliberate one."""
+    assert all(
+        table == {"approval_mode": "prompt"}
+        for table in codex_approval_rules().values()
+    )
+
+
+def test_codex_approval_rules_cannot_be_mutated_between_callers():
+    rules = codex_approval_rules()
+    rules.clear()
+    assert codex_approval_rules()
 
 
 def test_a_telegram_write_is_never_annotated_read_only(tools):


### PR DESCRIPTION
`slop-writer install` wired exactly one client: Claude Code. For anyone else it
printed a JSON entry to paste by hand — which is not a fallback for Codex at
all, because Codex is configured in TOML, so the text on offer could not be
pasted anywhere.

The cost was not the typing. A Codex user who registered the server themselves
got all eleven tools with **no gate on the three publishing ones**: the human
approval that 0006 moved into the distribution went back to being homework, and
it went back silently. They also got no skill in a directory Codex reads, so the
agent called the metric tools without the invariants that keep the numbers
honest.

From 0.5.0 `install` and `uninstall` take a repeatable `--client` (`claude`,
`codex`), write each selected client's own wiring, and report what landed for
which. Full rationale in
[adr/0008](docs/adr/0008-install-writes-more-than-one-client.md); 0006 is
amended where it no longer reads as written.

## What lands on disk

```toml
[mcp_servers.slop-writer]
command = "slop-writer"
args = ["serve", "--mcp"]

[mcp_servers.slop-writer.tools.publish_schedule]
approval_mode = "prompt"      # and publish_reschedule, publish_edit
```

| artifact | owner | idempotency |
| --- | --- | --- |
| `.mcp.json` entry | Claude Code | rewritten every run |
| `.claude/settings.json` permissions | Claude Code, the human's | first install only |
| `.claude/skills/<skill>/` | Claude Code | replaced wholesale |
| `CLAUDE.md` address block | Claude Code, the human's | first install only |
| `.codex/config.toml` server entry | Codex | rewritten every run |
| `.codex/config.toml` `tools` tables | Codex, the human's | first install only |
| `AGENTS.md` address block | no client | written when absent |
| `.agents/skills/<skill>/` | no client | replaced wholesale |

The last two rows belong to no client on purpose: `AGENTS.md` is a cross-agent
convention, and `.agents/skills/` is the one skill root Codex finds with no
configuration layer involved — so it keeps working in a directory the human has
not trusted yet. Only an unnarrowed `uninstall` removes them.

## The decisions worth reviewing

- **The Codex gate is emitted from `server.py`, not translated in
  `install.py`.** `codex_approval_rules()` is a sibling of `permission_rules()`
  because the roster and its gate are one fact — a tool renamed without its rule
  loses the gate silently, and it loses it on the client nobody is watching. The
  suite compares both emitters against `WRITE_TOOLS` and against each other.
- **Three explicit per-tool tables**, not one server-level
  `default_tools_approval_mode`: the explicit form names the same three tools
  the roster names, which is what makes the invariant checkable. Note
  `approval_mode` has no deny value — this axis can only put a human in front of
  a Telegram write.
- **Selection, never detection.** `--client` defaults to `claude` on install, so
  a project that only ever used one client holds exactly what it held before;
  it defaults to *every* client on uninstall, which is safe only because
  uninstall removes nothing but its own markers. Autodetection would write
  artifacts nobody asked for and leave `uninstall` guessing.
- **TOML without a dependency.** Reading is `tomllib`; writing is a small
  emitter internal to `install.py` that emits our tables and nothing else — the
  rest of the file is carried across as text, so a human's comment three tables
  down comes out byte for byte. The one form it refuses is our entry written as
  an inline table or a dotted key: appending a `[table]` header beside it would
  be a duplicate definition, so `install` names the file and stops.
- **First-install detection is per client** ("our own key is absent", still no
  marker file), since a project can be a first install for one client and an
  upgrade for another. Mixed ownership *inside* one file is new here: Codex
  keeps the server entry and the approval decisions in the same file, and Codex
  itself writes `approval_mode` there when a human answers "don't ask me again".

## Known gaps, recorded rather than hidden

- **No timeout in the Codex entry.** `.mcp.json` carries `timeout = 600000`
  because a scrape runs for minutes; Codex names that idea differently
  (`startup_timeout_sec` / `tool_timeout_sec`) and an unverified key risks the
  whole project layer being rejected, gate included. If a live scrape is cut
  short, the fix is `tool_timeout_sec` in `codex_server_entry()`.
- **Reads are unlisted**, so they inherit Codex's default. "A reading tool call
  raises no prompt" is a live acceptance check; if it fails the answer is a
  server-level default *beside* the three tables, not instead of them.
- **Codex ignores a project layer until the human trusts the directory**, and
  that trust lives in their global config — so a fresh clone gets a working
  `.mcp.json` and an inert `.codex/config.toml`. `install` reports it; this
  project does not write another tool's global file.
- **A managed macOS MDM preference outranks the project layer** and cannot be
  detected by a path check. The file forms are checked and refused.
- Cursor and the Copilot coding agent **stay** on the printed-entry list: their
  launch cwd is still unverified.

## Tests

`tests/test_install.py` grew to 57 cases: multi-client selection and defaults,
per-client idempotency and first-install seeding, the TOML emitter's
round-trip preservation, the inline-table refusal, and narrowed vs. unnarrowed
uninstall. `tests/test_server.py` adds four Codex-specific ones, including
`test_the_codex_gate_asks_and_never_forbids` and a check that the entry carries
no machine-specific string — the conservative answer to the launch-directory
question, pinned so a live run that contradicts it forces a deliberate change.

Version bumped to 0.5.0 in `pyproject.toml` and `SKILL.md`. Not yet run against
a live Codex session — the acceptance checks above are the first thing to do
after merge.
